### PR TITLE
[matches] Add basic matches service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,23 @@ services:
     networks: 
       - user-network 
 
+  matches:
+    build: ./matches
+    ports:
+      - "81:80" 
+    networks: 
+      - matches-network 
+    
+  matches-db:
+    image: postgres:12.1 
+    environment:
+      - PGUSER=postgres
+    volumes:
+      - ./matches-db/init.sql:/docker-entrypoint-initdb.d/init.sql
+    networks: 
+      - matches-network 
+  
+
 networks:
   user-network:
+  matches-network:

--- a/matches-db/init.sql
+++ b/matches-db/init.sql
@@ -1,0 +1,1 @@
+CREATE TABLE Matches (userOne int, userTwo int);

--- a/matches/Dockerfile
+++ b/matches/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.13.7-alpine
+
+WORKDIR /go/src/github.com/TempleEight/spec-golang/matches/
+
+COPY . .
+
+RUN apk add --no-cache git
+
+RUN go get github.com/gorilla/mux
+RUN go get github.com/lib/pq
+
+RUN go build -o matches
+
+ENTRYPOINT ./matches
+
+EXPOSE 80

--- a/matches/matches.go
+++ b/matches/matches.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/matches", matchGetHandler).Methods(http.MethodGet)
+
+	log.Fatal(http.ListenAndServe(":80", r))
+}
+
+func matchGetHandler(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode("Hello, World")
+}


### PR DESCRIPTION
Add a service for "matches" - this will combine a match between two "users".

Currently this is exposed via port 81, however I'll work on an API Gateway next that unifies access to the services

```
~/g/s/g/T/spec-golang ❯❯❯ docker-compose up --build
```
```
~/g/s/g/T/spec-golang ❯❯❯ curl localhost:81/matches
"Hello, World"

~/g/s/g/T/spec-golang ❯❯❯ curl localhost:80/user/1
{"ID":1,"Name":"Andrew"}
```



NB: You may need to tidy up the `Postgres` volumes to test from a fresh DB:

```
~/g/s/g/T/spec-golang ❯❯❯ docker volume prune -f
```