### PR TITLE
[api-gateway] Add basic API gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "80:80" 
     networks: 
       - user-network 
+      - kong-network
 
   user-db:
     image: postgres:12.1 
@@ -20,9 +21,10 @@ services:
   matches:
     build: ./matches
     ports:
-      - "81:80" 
+      - "81:81" 
     networks: 
       - matches-network 
+      - kong-network
     
   matches-db:
     image: postgres:12.1 
@@ -32,8 +34,72 @@ services:
       - ./matches-db/init.sql:/docker-entrypoint-initdb.d/init.sql
     networks: 
       - matches-network 
-  
+
+  # API Gateway
+  kong-migrations:
+    image: kong:latest 
+    command: kong migrations bootstrap && kong migrations up && kong migrations finish
+    depends_on:
+      - kong-db
+    environment:
+      KONG_DATABASE: postgres
+      KONG_PG_DATABASE: kong 
+      KONG_PG_HOST: kong-db
+      KONG_PG_PASSWORD: kong 
+      KONG_PG_USER: kong 
+    networks:
+      - kong-network
+    restart: on-failure
+
+  kong:
+    image: kong:latest
+    user: kong
+    depends_on:
+      - kong-db
+    environment:
+      KONG_ADMIN_ACCESS_LOG: /dev/stdout
+      KONG_ADMIN_ERROR_LOG: /dev/stderr
+      KONG_PROXY_ACCESS_LOG: /dev/stdout
+      KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_ADMIN_LISTEN: '0.0.0.0:8001'
+      KONG_CASSANDRA_CONTACT_POINTS: kong-db
+      KONG_DATABASE: postgres
+      KONG_PG_DATABASE: kong 
+      KONG_PG_HOST: kong-db
+      KONG_PG_PASSWORD: kong
+      KONG_PG_USER: kong 
+    networks:
+      - kong-network
+    ports:
+      - "8000:8000/tcp"
+      - "8001:8001/tcp"
+      - "8443:8443/tcp"
+      - "8444:8444/tcp"
+    healthcheck:
+      test: ["CMD", "kong", "health"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+    restart: on-failure
+    
+  kong-db:
+    image: postgres:9.5
+    environment:
+      - POSTGRES_DB=kong
+      - POSTGRES_PASSWORD=kong
+      - POSTGRES_USER=kong
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${KONG_PG_USER:-kong}"]
+      interval: 30s
+      timeout: 30s
+      retries: 3
+    restart: on-failure
+    stdin_open: true
+    tty: true
+    networks:
+      - kong-network
 
 networks:
   user-network:
   matches-network:
+  kong-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     restart: on-failure
 
   kong:
-    image: kong:latest
+    image: kong:2.0.1
     user: kong
     depends_on:
       - kong-db
@@ -83,13 +83,13 @@ services:
     restart: on-failure
     
   kong-db:
-    image: postgres:9.5
+    image: postgres:12.1
     environment:
       - POSTGRES_DB=kong
       - POSTGRES_PASSWORD=kong
       - POSTGRES_USER=kong
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "${KONG_PG_USER:-kong}"]
+      test: ["CMD", "pg_isready", "-U", "kong"]
       interval: 30s
       timeout: 30s
       retries: 3

--- a/kong/configure-kong.sh
+++ b/kong/configure-kong.sh
@@ -1,0 +1,25 @@
+#!/bin/sh 
+
+# Add the user service
+curl -i -X POST \
+  --url http://localhost:8001/services/ \
+  --data 'name=user-service' \
+  --data 'url=http://user:80/user'
+
+# Add the matches service
+curl -i -X POST \
+  --url http://localhost:8001/services/ \
+  --data 'name=matches-service' \
+  --data 'url=http://matches:81/matches'
+
+# Add a route for users
+curl -i -X POST \
+  --url http://localhost:8001/services/user-service/routes \
+  --data 'hosts[]=localhost:8000' \
+  --data 'paths[]=/api/user'
+
+# Add a route for matches
+curl -i -X POST \
+  --url http://localhost:8001/services/matches-service/routes \
+  --data 'hosts[]=localhost:8000' \
+  --data 'paths[]=/api/matches'

--- a/matches/Dockerfile
+++ b/matches/Dockerfile
@@ -13,4 +13,4 @@ RUN go build -o matches
 
 ENTRYPOINT ./matches
 
-EXPOSE 80
+EXPOSE 81

--- a/matches/matches.go
+++ b/matches/matches.go
@@ -12,7 +12,7 @@ func main() {
 	r := mux.NewRouter()
 	r.HandleFunc("/matches", matchGetHandler).Methods(http.MethodGet)
 
-	log.Fatal(http.ListenAndServe(":80", r))
+	log.Fatal(http.ListenAndServe(":81", r))
 }
 
 func matchGetHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Add an API Gateway, such that requests can be directed to a single endpoint.
This PR makes a couple of changes:
- Changes the exposed port of matches service to 81
- Adds an additional network for the API Gateway to share with each service - you can visualise the network infrastructure as:

```
             +-----------------------------------------------+ kong-network
             |                                               |
             |                                               |
             |                                               |
             |                                               |
             |                                               |
             |                    kong                       |
             |                                               |
             |                                               |
             |                                               |
        +----|---------------------+   +---------------------|-----+
        |    |                     |   |                     |     |
        |    |                     |   |                     |     |
        |    |    user-svc         |   |      matches-svc    |     |
        |    |                     |   |                     |     |
        |    |                     |   |                     |     |
        |    +-----------------------------------------------+     |
        |                          |   |                           |
        |                          |   |                           |
        |                          |   |                           |
        |                          |   |                           |
        |    user-postgres         |   |      matches-postgres     |
        |                          |   |                           |
        |                          |   |                           |
        |                          |   |                           |
        +--------------------------+   +---------------------------+
        user-network                                matches-network
```
- This stops the two Postgres instances from interacting → Not sure if this is the best way to do it, will probably change in the future if we actually deploy the services to something other than localhost


To test:
```
$ docker-compose up --build
$ sh kong/configure-kong.sh
```
```
$ curl localhost:8000/api/user/1
{"ID":1,"Name":"Andrew"}
```
```
$ curl localhost:8000/api/matches
"Hello, World"
```

The services are also individually accessible via `localhost:80` and `localhost:81`