### PR TITLE
[tidy] Misc fixes to User and Match services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
   # API Gateway
   kong-migrations:
-    image: kong:latest 
+    image: kong:2.0.1
     command: kong migrations bootstrap && kong migrations up && kong migrations finish
     depends_on:
       - kong-db

--- a/match/dao/match-dao.go
+++ b/match/dao/match-dao.go
@@ -16,8 +16,8 @@ type DAO struct {
 
 // MatchCreateRequest contains the information required to create a new match
 type MatchCreateRequest struct {
-	UserOne int `valid:"-"`
-	UserTwo int `valid:"-"`
+	UserOne *int `valid:"-"`
+	UserTwo *int `valid:"-"`
 }
 
 // MatchGetResponse contains the information stored about a given match
@@ -30,8 +30,8 @@ type MatchGetResponse struct {
 
 // MatchUpdateRequest contains the information required to update a match
 type MatchUpdateRequest struct {
-	UserOne int `valid:"-"`
-	UserTwo int `valid:"-"`
+	UserOne *int `valid:"-"`
+	UserTwo *int `valid:"-"`
 }
 
 // MatchListResponse contains the information stored about all matches

--- a/match/dao/match-dao.go
+++ b/match/dao/match-dao.go
@@ -73,7 +73,7 @@ func (dao *DAO) Initialise(config *utils.Config) error {
 
 // CreateMatch inserts a new match into the database given two user IDs
 func (dao *DAO) CreateMatch(request MatchCreateRequest) error {
-	_, err := executeQuery(dao.DB, "INSERT INTO Match (userOne, userTwo, matchedOn) VALUES ($1, $2, NOW()) RETURNING *", request.UserOne, request.UserTwo)
+	_, err := executeQuery(dao.DB, "INSERT INTO Match (userOne, userTwo, matchedOn) VALUES ($1, $2, NOW())", request.UserOne, request.UserTwo)
 	return err
 }
 
@@ -100,7 +100,7 @@ func (dao *DAO) GetMatch(id int64) (*MatchGetResponse, error) {
 
 // UpdateMatch updates an already existing match to two user IDs
 func (dao *DAO) UpdateMatch(matchID int64, request MatchUpdateRequest) error {
-	rowsAffected, err := executeQuery(dao.DB, "UPDATE Match SET userOne = $1, userTwo = $2 WHERE id = $3", request.UserOne, request.UserTwo, matchID)
+	rowsAffected, err := executeQuery(dao.DB, "UPDATE Match SET userOne = $1, userTwo = $2, matchedOn = NOW() WHERE id = $3", request.UserOne, request.UserTwo, matchID)
 	if err != nil {
 		return err
 	} else if rowsAffected == 0 {

--- a/match/match.go
+++ b/match/match.go
@@ -34,10 +34,10 @@ func main() {
 	}
 
 	r := mux.NewRouter()
-	r.HandleFunc("/match/{id}", matchGetHandler).Methods(http.MethodGet)
 	r.HandleFunc("/match", matchCreateHandler).Methods(http.MethodPost)
+	r.HandleFunc("/match/{id}", matchGetHandler).Methods(http.MethodGet)
 	r.HandleFunc("/match/{id}", matchDeleteHandler).Methods(http.MethodDelete)
-	r.HandleFunc("/match", matchUpdateHandler).Methods(http.MethodPatch)
+	r.HandleFunc("/match/{id}", matchUpdateHandler).Methods(http.MethodPut)
 	r.HandleFunc("/matches/{id}", matchListHandler).Methods(http.MethodGet)
 	r.Use(jsonMiddleware)
 
@@ -50,6 +50,31 @@ func jsonMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 		next.ServeHTTP(w, r)
 	})
+}
+
+func matchCreateHandler(w http.ResponseWriter, r *http.Request) {
+	var req matchDAO.MatchCreateRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	_, err = valid.ValidateStruct(req)
+	if err != nil {
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	err = dao.CreateMatch(req)
+	if err != nil {
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(struct{}{})
 }
 
 func matchGetHandler(w http.ResponseWriter, r *http.Request) {
@@ -74,14 +99,29 @@ func matchGetHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(match)
 }
 
-func matchListHandler(w http.ResponseWriter, r *http.Request) {
-	userID, err := utils.ExtractIDFromRequest(mux.Vars(r))
+func matchUpdateHandler(w http.ResponseWriter, r *http.Request) {
+	matchID, err := utils.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
 		http.Error(w, utils.CreateErrorJSON(err.Error()), http.StatusBadRequest)
 		return
 	}
 
-	matches, err := dao.ListMatch(userID)
+	var req matchDAO.MatchUpdateRequest
+	err = json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	_, err = valid.ValidateStruct(req)
+	if err != nil {
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	err = dao.UpdateMatch(matchID, req)
 	if err != nil {
 		switch err.(type) {
 		case matchDAO.ErrMatchNotFound:
@@ -92,26 +132,7 @@ func matchListHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-
-	json.NewEncoder(w).Encode(matches)
-}
-
-func matchCreateHandler(w http.ResponseWriter, r *http.Request) {
-	var req matchDAO.MatchCreateRequest
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusBadRequest)
-		return
-	}
-
-	response, err := dao.CreateMatch(req)
-	if err != nil {
-		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusInternalServerError)
-		return
-	}
-	json.NewEncoder(w).Encode(response)
+	json.NewEncoder(w).Encode(struct{}{})
 }
 
 func matchDeleteHandler(w http.ResponseWriter, r *http.Request) {
@@ -135,16 +156,14 @@ func matchDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(struct{}{})
 }
 
-func matchUpdateHandler(w http.ResponseWriter, r *http.Request) {
-	var req matchDAO.MatchUpdateRequest
-	err := json.NewDecoder(r.Body).Decode(&req)
+func matchListHandler(w http.ResponseWriter, r *http.Request) {
+	userID, err := utils.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
-		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusBadRequest)
+		http.Error(w, utils.CreateErrorJSON(err.Error()), http.StatusBadRequest)
 		return
 	}
 
-	err = dao.UpdateMatch(req)
+	matches, err := dao.ListMatch(userID)
 	if err != nil {
 		switch err.(type) {
 		case matchDAO.ErrMatchNotFound:
@@ -155,5 +174,6 @@ func matchUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	json.NewEncoder(w).Encode(struct{}{})
+
+	json.NewEncoder(w).Encode(matches)
 }

--- a/match/match.go
+++ b/match/match.go
@@ -60,6 +60,11 @@ func matchCreateHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, errMsg, http.StatusBadRequest)
 		return
 	}
+	if req.UserOne == nil || req.UserTwo == nil {
+		errMsg := utils.CreateErrorJSON("Missing request parameter")
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
 
 	_, err = valid.ValidateStruct(req)
 	if err != nil {
@@ -110,6 +115,11 @@ func matchUpdateHandler(w http.ResponseWriter, r *http.Request) {
 	err = json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+	if req.UserOne == nil || req.UserTwo == nil {
+		errMsg := utils.CreateErrorJSON("Missing request parameter")
 		http.Error(w, errMsg, http.StatusBadRequest)
 		return
 	}

--- a/match/match.go
+++ b/match/match.go
@@ -61,7 +61,7 @@ func matchCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if req.UserOne == nil || req.UserTwo == nil {
-		errMsg := utils.CreateErrorJSON("Missing request parameter")
+		errMsg := utils.CreateErrorJSON("Missing request parameter(s)")
 		http.Error(w, errMsg, http.StatusBadRequest)
 		return
 	}

--- a/user-db/init.sql
+++ b/user-db/init.sql
@@ -1,4 +1,4 @@
-CREATE TABLE UserTbl (
+CREATE TABLE User_Temple (
     id SERIAL PRIMARY KEY,
     name TEXT
 );

--- a/user-db/init.sql
+++ b/user-db/init.sql
@@ -1,4 +1,4 @@
-CREATE TABLE Users (
+CREATE TABLE UserTbl (
     id SERIAL PRIMARY KEY,
     name TEXT
 );

--- a/user/dao/user-dao.go
+++ b/user/dao/user-dao.go
@@ -66,7 +66,7 @@ func (dao *DAO) Initialise(config *utils.Config) error {
 
 // GetUser returns the information about a user stored for a given ID
 func (dao *DAO) GetUser(id int64) (*UserGetResponse, error) {
-	row, err := executeQueryWithRowResponse(dao.DB, "SELECT * FROM Users WHERE id = $1", id)
+	row, err := executeQueryWithRowResponse(dao.DB, "SELECT * FROM UserTbl WHERE id = $1", id)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (dao *DAO) GetUser(id int64) (*UserGetResponse, error) {
 
 // CreateUser creates a new user in the database, returning the newly created user
 func (dao *DAO) CreateUser(request UserCreateRequest) (*UserCreateResponse, error) {
-	row, err := executeQueryWithRowResponse(dao.DB, "INSERT INTO Users (name) VALUES ($1) RETURNING *", request.Name)
+	row, err := executeQueryWithRowResponse(dao.DB, "INSERT INTO UserTbl (name) VALUES ($1) RETURNING *", request.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (dao *DAO) CreateUser(request UserCreateRequest) (*UserCreateResponse, erro
 
 // UpdateUser updates a user in the database, returning an error if it fails
 func (dao *DAO) UpdateUser(userID int64, request UserUpdateRequest) error {
-	query := "UPDATE Users set Name = $1 WHERE Id = $2"
+	query := "UPDATE UserTbl set Name = $1 WHERE Id = $2"
 	rowsAffected, err := executeQuery(dao.DB, query, request.Name, userID)
 	if err != nil {
 		return err
@@ -121,7 +121,7 @@ func (dao *DAO) UpdateUser(userID int64, request UserUpdateRequest) error {
 
 // DeleteUser deletes a user in the database, returning an error if it fails or the user doesn't exist
 func (dao *DAO) DeleteUser(userID int64) error {
-	rowsAffected, err := executeQuery(dao.DB, "DELETE FROM Users WHERE Id = $1", userID)
+	rowsAffected, err := executeQuery(dao.DB, "DELETE FROM UserTbl WHERE Id = $1", userID)
 	if err != nil {
 		return err
 	} else if rowsAffected == 0 {

--- a/user/dao/user-dao.go
+++ b/user/dao/user-dao.go
@@ -66,7 +66,7 @@ func (dao *DAO) Initialise(config *utils.Config) error {
 
 // GetUser returns the information about a user stored for a given ID
 func (dao *DAO) GetUser(id int64) (*UserGetResponse, error) {
-	row, err := executeQueryWithRowResponse(dao.DB, "SELECT * FROM UserTbl WHERE id = $1", id)
+	row, err := executeQueryWithRowResponse(dao.DB, "SELECT * FROM User_Temple WHERE id = $1", id)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (dao *DAO) GetUser(id int64) (*UserGetResponse, error) {
 
 // CreateUser creates a new user in the database, returning the newly created user
 func (dao *DAO) CreateUser(request UserCreateRequest) (*UserCreateResponse, error) {
-	row, err := executeQueryWithRowResponse(dao.DB, "INSERT INTO UserTbl (name) VALUES ($1) RETURNING *", request.Name)
+	row, err := executeQueryWithRowResponse(dao.DB, "INSERT INTO User_Temple (name) VALUES ($1) RETURNING *", request.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (dao *DAO) CreateUser(request UserCreateRequest) (*UserCreateResponse, erro
 
 // UpdateUser updates a user in the database, returning an error if it fails
 func (dao *DAO) UpdateUser(userID int64, request UserUpdateRequest) error {
-	query := "UPDATE UserTbl set Name = $1 WHERE Id = $2"
+	query := "UPDATE User_Temple set Name = $1 WHERE Id = $2"
 	rowsAffected, err := executeQuery(dao.DB, query, request.Name, userID)
 	if err != nil {
 		return err
@@ -121,7 +121,7 @@ func (dao *DAO) UpdateUser(userID int64, request UserUpdateRequest) error {
 
 // DeleteUser deletes a user in the database, returning an error if it fails or the user doesn't exist
 func (dao *DAO) DeleteUser(userID int64) error {
-	rowsAffected, err := executeQuery(dao.DB, "DELETE FROM UserTbl WHERE Id = $1", userID)
+	rowsAffected, err := executeQuery(dao.DB, "DELETE FROM User_Temple WHERE Id = $1", userID)
 	if err != nil {
 		return err
 	} else if rowsAffected == 0 {

--- a/user/dao/user-dao.go
+++ b/user/dao/user-dao.go
@@ -2,7 +2,6 @@ package dao
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 
 	"github.com/TempleEight/spec-golang/user/utils"
@@ -15,19 +14,13 @@ type DAO struct {
 	DB *sql.DB
 }
 
-// UserGetResponse returns all the information stored about a user
-type UserGetResponse struct {
-	ID   int
-	Name string
-}
-
 // UserCreateRequest contains the information required to create a new user
 type UserCreateRequest struct {
 	Name string `valid:"type(string),required,stringlength(2|255)"`
 }
 
-// UserCreateResponse contains the information stored about the newly created user
-type UserCreateResponse struct {
+// UserGetResponse returns all the information stored about a user
+type UserGetResponse struct {
 	ID   int
 	Name string
 }
@@ -64,6 +57,12 @@ func (dao *DAO) Initialise(config *utils.Config) error {
 	return nil
 }
 
+// CreateUser creates a new user in the database
+func (dao *DAO) CreateUser(request UserCreateRequest) error {
+	_, err := executeQuery(dao.DB, "INSERT INTO User_Temple (name) VALUES ($1) RETURNING *", request.Name)
+	return err
+}
+
 // GetUser returns the information about a user stored for a given ID
 func (dao *DAO) GetUser(id int64) (*UserGetResponse, error) {
 	row, err := executeQueryWithRowResponse(dao.DB, "SELECT * FROM User_Temple WHERE id = $1", id)
@@ -85,31 +84,9 @@ func (dao *DAO) GetUser(id int64) (*UserGetResponse, error) {
 	return &user, nil
 }
 
-// CreateUser creates a new user in the database, returning the newly created user
-func (dao *DAO) CreateUser(request UserCreateRequest) (*UserCreateResponse, error) {
-	row, err := executeQueryWithRowResponse(dao.DB, "INSERT INTO User_Temple (name) VALUES ($1) RETURNING *", request.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	var user UserCreateResponse
-	err = row.Scan(&user.ID, &user.Name)
-	if err != nil {
-		switch err {
-		case sql.ErrNoRows:
-			return nil, errors.New("Could not create user")
-		default:
-			return nil, err
-		}
-	}
-
-	return &user, nil
-}
-
 // UpdateUser updates a user in the database, returning an error if it fails
 func (dao *DAO) UpdateUser(userID int64, request UserUpdateRequest) error {
-	query := "UPDATE User_Temple set Name = $1 WHERE Id = $2"
-	rowsAffected, err := executeQuery(dao.DB, query, request.Name, userID)
+	rowsAffected, err := executeQuery(dao.DB, "UPDATE User_Temple set Name = $1 WHERE Id = $2", request.Name, userID)
 	if err != nil {
 		return err
 	} else if rowsAffected == 0 {

--- a/user/user.go
+++ b/user/user.go
@@ -52,7 +52,7 @@ func jsonMiddleware(next http.Handler) http.Handler {
 }
 
 func userGetHandler(w http.ResponseWriter, r *http.Request) {
-	userID, err := utils.ExtractUserIDFromRequest(mux.Vars(r))
+	userID, err := utils.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
 		http.Error(w, utils.CreateErrorJSON(err.Error()), http.StatusBadRequest)
 		return
@@ -98,7 +98,7 @@ func userCreateHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func userUpdateHandler(w http.ResponseWriter, r *http.Request) {
-	userID, err := utils.ExtractUserIDFromRequest(mux.Vars(r))
+	userID, err := utils.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
 		http.Error(w, utils.CreateErrorJSON(err.Error()), http.StatusBadRequest)
 		return
@@ -134,7 +134,7 @@ func userUpdateHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func userDeleteHandler(w http.ResponseWriter, r *http.Request) {
-	userID, err := utils.ExtractUserIDFromRequest(mux.Vars(r))
+	userID, err := utils.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
 		http.Error(w, utils.CreateErrorJSON(err.Error()), http.StatusBadRequest)
 		return

--- a/user/user.go
+++ b/user/user.go
@@ -51,6 +51,31 @@ func jsonMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+func userCreateHandler(w http.ResponseWriter, r *http.Request) {
+	var req userDAO.UserCreateRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	_, err = valid.ValidateStruct(req)
+	if err != nil {
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	err = dao.CreateUser(req)
+	if err != nil {
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(struct{}{})
+}
+
 func userGetHandler(w http.ResponseWriter, r *http.Request) {
 	userID, err := utils.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
@@ -70,31 +95,6 @@ func userGetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	json.NewEncoder(w).Encode(user)
-}
-
-func userCreateHandler(w http.ResponseWriter, r *http.Request) {
-	var req userDAO.UserCreateRequest
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusBadRequest)
-		return
-	}
-
-	_, err = valid.ValidateStruct(req)
-	if err != nil {
-		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusBadRequest)
-		return
-	}
-
-	response, err := dao.CreateUser(req)
-	if err != nil {
-		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusInternalServerError)
-		return
-	}
-	json.NewEncoder(w).Encode(response)
 }
 
 func userUpdateHandler(w http.ResponseWriter, r *http.Request) {

--- a/user/utils/utils.go
+++ b/user/utils/utils.go
@@ -33,17 +33,17 @@ func CreateErrorJSON(message string) string {
 	return string(json)
 }
 
-// ExtractUserIDFromRequest extracts the parameter provided under parameter ID and converts it into an integer
-func ExtractUserIDFromRequest(requestParams map[string]string) (int64, error) {
-	userIDStr := requestParams["id"]
-	if len(userIDStr) == 0 {
-		return 0, errors.New("No user ID provided")
+// ExtractIDFromRequest extracts the parameter provided under parameter ID and converts it into an integer
+func ExtractIDFromRequest(requestParams map[string]string) (int64, error) {
+	idStr := requestParams["id"]
+	if len(idStr) == 0 {
+		return 0, errors.New("No ID provided")
 	}
 
-	userID, err := strconv.ParseInt(userIDStr, 10, 64)
+	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		return 0, errors.New("Invalid user ID provided")
+		return 0, errors.New("Invalid ID provided")
 	}
 
-	return userID, nil
+	return id, nil
 }


### PR DESCRIPTION
* Assigns a fixed version to Kong docker image
* Reorders functions/structs to follow CRUD
* Adds an ignore flag, `valid:"-"`, to Match structs
  * This means govalidator's `validateStruct` can be called on the struct without causing an error
  * Though we don't need to call `validateStruct` on them anyway, so could take out (but would mean more effort code generating later"
* Forces calls to CREATE and UPDATE to pass all fields
  * Makes CREATE and UPDATE request struct fields pointers, so it can be discerned if they were omitted (otherwise they take zero-value)
* Renames `Users` table to `User_Temple`
  * Avoids pluralising problem, e.g. `User` -> `Users`, `Match` -> `Matches`
  * Unfortunately `User` is reserved in Postgres, `Temple` suffix handles this
    * Decision made to maintain a map of reserved names when generating
* Removes User and Match CREATE endpoints returning the row, returns `{}` to match UPDATE
* Change Match UPDATE to be a HTTP PUT rather than PATCH
* Rename `ExtractUserIDFromRequest` in User service to `ExtractIDFromRequest`, to match the same function in Match service (less code to generate)

The diff here is not the best because of the reordering of functions/structs to follow CRUD. If too hard to follow LMK and I'll put the reordering in a separate PR. I've tried to detail everything above to mitigate.

#### Test plan

```
> ./build.sh
> sh kong/configure-kong.sh
```

User service:
```
> curl -X GET localhost:8000/api/user/1
{"error":"user not found with ID 1"}
> curl -X POST localhost:8000/api/user -d '{"name":"Will"}'
{}
> curl -X GET localhost:8000/api/user/1
{"ID":1,"Name":"Will"}
> curl -X PUT localhost:8000/api/user/1 -d '{"name":"Charlie"}'
{}
> curl -X GET localhost:8000/api/user/1
{"ID":1,"Name":"Charlie"}
> curl -X DELETE localhost:8000/api/user/1
{}
> curl -X GET localhost:8000/api/user/1
{"error":"user not found with ID 1"}
```

Match service:
```
> curl -X GET localhost:8000/api/match/1
{"error":"match not found with ID 1"}
> curl -X POST localhost:8000/api/match -d '{"UserOne":1, "UserTwo":2}'
{}
> curl -X GET localhost:8000/api/match/1
{"ID":1,"UserOne":1,"UserTwo":2,"MatchedOn":<TIME>}
> curl -X PUT localhost:8000/api/match/1 -d '{"UserOne":3, "UserTwo":4}'
{}
> curl -X GET localhost:8000/api/match/1
{"ID":1,"UserOne":3,"UserTwo":0,"MatchedOn":<TIME>}
> curl -X DELETE localhost:8000/api/match/1
{}
> curl -X GET localhost:8000/api/match/1
{"error":"match not found with ID 1"}
```

Missing fields:
```
> curl -X POST localhost:8000/api/match -d '{"UserOne":5}'
{"error":"Missing request parameter(s)"}
> curl -X POST localhost:8000/api/match -d '{"UserOne":5, "UserTwo":6}'
{}
> curl -X PUT localhost:8000/api/match/1 -d '{"UserOne":7}'
{"error":"Missing request parameter(s)"}
```