### PR TITLE
[tidy] Fix all matches endpoint

### DIFF
--- a/kong/configure-kong.sh
+++ b/kong/configure-kong.sh
@@ -12,13 +12,7 @@ curl -i -X POST \
   --data 'name=match-service' \
   --data 'url=http://match:81/match'
 
-# Add the matches service
-curl -i -X POST \
-  --url http://localhost:8001/services/ \
-  --data 'name=matches-service' \
-  --data 'url=http://match:81/matches'
-
-# Add a route for users
+# Add a route for user
 curl -i -X POST \
   --url http://localhost:8001/services/user-service/routes \
   --data 'hosts[]=localhost:8000' \
@@ -29,9 +23,3 @@ curl -i -X POST \
   --url http://localhost:8001/services/match-service/routes \
   --data 'hosts[]=localhost:8000' \
   --data 'paths[]=/api/match'
-
-# Add a route for matches
-curl -i -X POST \
-  --url http://localhost:8001/services/matches-service/routes \
-  --data 'hosts[]=localhost:8000' \
-  --data 'paths[]=/api/matches'

--- a/match/dao/match-dao.go
+++ b/match/dao/match-dao.go
@@ -122,7 +122,7 @@ func (dao *DAO) DeleteMatch(id int64) error {
 	return nil
 }
 
-// ListMatch lists all matches
+// ListMatch returns a list containing every match
 func (dao *DAO) ListMatch() (*MatchListResponse, error) {
 	rows, err := executeQueryWithResponses(dao.DB, "SELECT * FROM Match")
 	if err != nil {

--- a/match/dao/match-dao.go
+++ b/match/dao/match-dao.go
@@ -36,7 +36,7 @@ type MatchUpdateRequest struct {
 
 // MatchListResponse contains the information stored about all matches
 type MatchListResponse struct {
-	IDs []int
+	MatchList []MatchGetResponse
 }
 
 // Executes the query, returning the rows
@@ -122,27 +122,22 @@ func (dao *DAO) DeleteMatch(id int64) error {
 	return nil
 }
 
-// ListMatch lists all the matches which feature a user
-func (dao *DAO) ListMatch(id int64) (*MatchListResponse, error) {
-	rows, err := executeQueryWithResponses(dao.DB, "SELECT id FROM Match WHERE userOne = $1 OR userTwo = $1", id)
+// ListMatch lists all matches
+func (dao *DAO) ListMatch() (*MatchListResponse, error) {
+	rows, err := executeQueryWithResponses(dao.DB, "SELECT * FROM Match")
 	if err != nil {
 		return nil, err
 	}
 
-	var matches MatchListResponse
-	matches.IDs = make([]int, 0)
+	var matchList MatchListResponse
+	matchList.MatchList = make([]MatchGetResponse, 0)
 	for rows.Next() {
-		var match int
-		err = rows.Scan(&match)
+		var match MatchGetResponse
+		err = rows.Scan(&match.ID, &match.UserOne, &match.UserTwo, &match.MatchedOn)
 		if err != nil {
-			switch err {
-			case sql.ErrNoRows:
-				return nil, ErrMatchNotFound(id)
-			default:
-				return nil, err
-			}
+			return nil, err
 		}
-		matches.IDs = append(matches.IDs, match)
+		matchList.MatchList = append(matchList.MatchList, match)
 	}
 
 	err = rows.Err()
@@ -150,5 +145,5 @@ func (dao *DAO) ListMatch(id int64) (*MatchListResponse, error) {
 		return nil, err
 	}
 
-	return &matches, nil
+	return &matchList, nil
 }

--- a/match/match.go
+++ b/match/match.go
@@ -34,11 +34,12 @@ func main() {
 	}
 
 	r := mux.NewRouter()
+	// Mux redirects to first matching route, i.e. the order matters
+	r.HandleFunc("/match/all", matchListHandler).Methods(http.MethodGet)
 	r.HandleFunc("/match", matchCreateHandler).Methods(http.MethodPost)
 	r.HandleFunc("/match/{id}", matchGetHandler).Methods(http.MethodGet)
 	r.HandleFunc("/match/{id}", matchDeleteHandler).Methods(http.MethodDelete)
 	r.HandleFunc("/match/{id}", matchUpdateHandler).Methods(http.MethodPut)
-	r.HandleFunc("/matches/{id}", matchListHandler).Methods(http.MethodGet)
 	r.Use(jsonMiddleware)
 
 	log.Fatal(http.ListenAndServe(":81", r))
@@ -167,23 +168,12 @@ func matchDeleteHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func matchListHandler(w http.ResponseWriter, r *http.Request) {
-	userID, err := utils.ExtractIDFromRequest(mux.Vars(r))
+	matchList, err := dao.ListMatch()
 	if err != nil {
-		http.Error(w, utils.CreateErrorJSON(err.Error()), http.StatusBadRequest)
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
 		return
 	}
 
-	matches, err := dao.ListMatch(userID)
-	if err != nil {
-		switch err.(type) {
-		case matchDAO.ErrMatchNotFound:
-			http.Error(w, utils.CreateErrorJSON(err.Error()), http.StatusNotFound)
-		default:
-			errMsg := utils.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
-			http.Error(w, errMsg, http.StatusInternalServerError)
-		}
-		return
-	}
-
-	json.NewEncoder(w).Encode(matches)
+	json.NewEncoder(w).Encode(matchList)
 }


### PR DESCRIPTION
* Removes `matches` route, replace with `match/all`
* Makes `match/all` return all matches, including all fields for each one
* Identifiers are named to avoid pluralism problem, `match` -> `matches`

While it doesn't make sense for this sample service, we decided to omit the endpoint for fetching all matches for a user as it leads to high complexity in our DSL and subsequently in the parser. For now we're sticking with just generating CRUD, GET all, and GET all enumerable by one field endpoints. Shout out to the Oxford comma.

#### Test plan

```
> ./build.sh
> sh kong/configure-kong.sh
```

```
> curl -X GET localhost:8000/api/match/all
{"MatchList":[]}
> curl -X POST localhost:8000/api/match -d '{"UserOne":1, "UserTwo":2}'
{}
> curl -X GET localhost:8000/api/match/all
{"MatchList":[{"ID":1,"UserOne":1,"UserTwo":2,"MatchedOn":<TIME>}]}
```