### PR TITLE
[infra] Use go modules

### DIFF
--- a/match/Dockerfile
+++ b/match/Dockerfile
@@ -1,15 +1,12 @@
 FROM golang:1.13.7-alpine
 
-WORKDIR /go/src/github.com/TempleEight/spec-golang/match/
+WORKDIR /match
+
+COPY go.mod go.sum ./
+RUN go mod download
 
 COPY . .
 COPY config.json /etc/match-service/
-
-RUN apk add --no-cache git
-
-RUN go get github.com/gorilla/mux
-RUN go get github.com/lib/pq
-RUN go get github.com/asaskevich/govalidator
 
 RUN go build -o match
 

--- a/match/go.mod
+++ b/match/go.mod
@@ -1,0 +1,9 @@
+module github.com/TempleEight/spec-golang/match
+
+go 1.13
+
+require (
+	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
+	github.com/gorilla/mux v1.7.4
+	github.com/lib/pq v1.3.0
+)

--- a/match/go.sum
+++ b/match/go.sum
@@ -1,0 +1,6 @@
+github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
+github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
+github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/user/Dockerfile
+++ b/user/Dockerfile
@@ -1,18 +1,16 @@
 FROM golang:1.13.7-alpine
 
-WORKDIR /go/src/github.com/TempleEight/spec-golang/user/
+WORKDIR /user
+
+COPY go.mod go.sum ./
+RUN go mod download
 
 COPY . .
 COPY config.json /etc/user-service/
 
-RUN apk add --no-cache git
-
-RUN go get github.com/gorilla/mux
-RUN go get github.com/lib/pq
-RUN go get github.com/asaskevich/govalidator
-
-RUN go build -o user
+RUN go build -o user 
 
 ENTRYPOINT ./user
 
 EXPOSE 80
+

--- a/user/Dockerfile
+++ b/user/Dockerfile
@@ -13,4 +13,3 @@ RUN go build -o user
 ENTRYPOINT ./user
 
 EXPOSE 80
-

--- a/user/go.mod
+++ b/user/go.mod
@@ -1,0 +1,9 @@
+module github.com/TempleEight/spec-golang/user
+
+go 1.13
+
+require (
+	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
+	github.com/gorilla/mux v1.7.4
+	github.com/lib/pq v1.3.0
+)

--- a/user/go.sum
+++ b/user/go.sum
@@ -1,0 +1,6 @@
+github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
+github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
+github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=


### PR DESCRIPTION
Use go modules for dependency management, following https://blog.golang.org/using-go-modules.

This has the advantage that it doesn't need to be in the GOPATH, and makes the `Dockerfile` much easier generate 