### PR TITLE
[auth] Add a basic auth service

### DIFF
--- a/auth-db/init.sql
+++ b/auth-db/init.sql
@@ -1,0 +1,5 @@
+CREATE TABLE auth (
+    id SERIAL PRIMARY KEY,
+    email TEXT,
+    password TEXT
+);

--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.13.7-alpine
+
+WORKDIR /auth
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+COPY config.json /etc/auth-service/
+
+RUN go build -o auth
+
+ENTRYPOINT ./auth
+
+EXPOSE 82

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"log"
+	"net/http"
+
+	authDAO "github.com/TempleEight/spec-golang/auth/dao"
+	"github.com/TempleEight/spec-golang/auth/utils"
+	valid "github.com/asaskevich/govalidator"
+	"github.com/gorilla/mux"
+)
+
+var dao authDAO.DAO
+
+func main() {
+	configPtr := flag.String("config", "/etc/auth-service/config.json", "configuration filepath")
+	flag.Parse()
+
+	// Require all struct fields by default
+	valid.SetFieldsRequiredByDefault(true)
+
+	config, err := utils.GetConfig(*configPtr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dao = authDAO.DAO{}
+	err = dao.Init(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	r := mux.NewRouter()
+	r.HandleFunc("/auth", authCreateHandler).Methods(http.MethodPost)
+	log.Fatal(http.ListenAndServe(":82", r))
+}
+
+func authCreateHandler(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(struct{}{})
+}

--- a/auth/config.json
+++ b/auth/config.json
@@ -1,0 +1,7 @@
+{
+  "user": "postgres",
+  "dbName": "postgres",
+  "host": "auth-db",
+  "sslMode": "disable",
+  "services": {}
+}

--- a/auth/dao/auth-dao.go
+++ b/auth/dao/auth-dao.go
@@ -1,0 +1,26 @@
+package dao
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/TempleEight/spec-golang/auth/utils"
+	// pq acts as the driver for SQL requests
+	_ "github.com/lib/pq"
+)
+
+// DAO encapsulates access to the database
+type DAO struct {
+	DB *sql.DB
+}
+
+func (dao *DAO) Init(config *utils.Config) error {
+	connStr := fmt.Sprintf("user=%s dbname=%s host=%s sslmode=%s", config.User, config.DBName, config.Host, config.SSLMode)
+	var err error
+	dao.DB, err = sql.Open("postgres", connStr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -1,0 +1,9 @@
+module github.com/TempleEight/spec-golang/auth
+
+go 1.13
+
+require (
+	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
+	github.com/gorilla/mux v1.7.4
+	github.com/lib/pq v1.3.0
+)

--- a/auth/go.sum
+++ b/auth/go.sum
@@ -1,0 +1,6 @@
+github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
+github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
+github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/auth/utils/config.go
+++ b/auth/utils/config.go
@@ -1,0 +1,9 @@
+package utils
+
+type Config struct {
+	User    string `json:"user"`
+	DBName  string `json:"dbName"`
+	Host    string `json:"host"`
+	SSLMode string `json:"sslMode"`
+	Services map[string]string `json:"services"`
+}

--- a/auth/utils/utils.go
+++ b/auth/utils/utils.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// GetConfig returns a configuration object from decoding the given configuration file
+func GetConfig(filePath string) (*Config, error) {
+	config := Config{}
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	decoder := json.NewDecoder(file)
+	err = decoder.Decode(&config)
+	if err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,23 @@ services:
     networks: 
       - match-network
 
+  auth:
+    build: ./auth
+    ports:
+      - "82:82"
+    networks:
+      - auth-network
+      - kong-network
+
+  auth-db:
+    image: postgres:12.1
+    environment:
+      - PGUSER=postgres
+    volumes:
+      - ./auth-db/init.sql:/docker-entrypoint-initdb.d/init.sql
+    networks:
+      - auth-network
+
   # API Gateway
   kong-migrations:
     image: kong:2.0.1
@@ -102,4 +119,5 @@ services:
 networks:
   user-network:
   match-network:
+  auth-network:
   kong-network:

--- a/kong/configure-kong.sh
+++ b/kong/configure-kong.sh
@@ -12,6 +12,12 @@ curl -i -X POST \
   --data 'name=match-service' \
   --data 'url=http://match:81/match'
 
+# Add the auth service
+curl -i -X POST \
+  --url http://localhost:8001/services/ \
+  --data 'name=auth-service' \
+  --data 'url=http://auth:82/auth'
+
 # Add a route for user
 curl -i -X POST \
   --url http://localhost:8001/services/user-service/routes \
@@ -23,3 +29,10 @@ curl -i -X POST \
   --url http://localhost:8001/services/match-service/routes \
   --data 'hosts[]=localhost:8000' \
   --data 'paths[]=/api/match'
+
+# Add a route for auth 
+curl -i -X POST \
+  --url http://localhost:8001/services/auth-service/routes \
+  --data 'hosts[]=localhost:8000' \
+  --data 'paths[]=/api/auth'
+


### PR DESCRIPTION
We need an auth service. This is where tokens will be issued based on an email/password authentication and then future services will require this token before giving access to data.

This PR simply adds a basic auth service, with Dockerfile / Postgres db etc. and hooks it in with Kong and Docker-Compose.

Test:
```
❯❯❯ docker-compose up --build
❯❯❯ sh kong/configure-kong.sh
❯❯❯ curl -X POST localhost:8000/api/auth
{}
```