### PR TITLE
[auth] Register a new email/password combination and return a JWT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 #
 *.vscode
+*.idea

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -84,7 +84,6 @@ func authCreateHandler(w http.ResponseWriter, r *http.Request) {
 		AccessToken: accessToken,
 	}
 	json.NewEncoder(w).Encode(response)
-
 }
 
 // Create an access token with a 24 hour lifetime

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -3,12 +3,16 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
+	"golang.org/x/crypto/bcrypt"
 	"log"
 	"net/http"
+	"time"
 
 	authDAO "github.com/TempleEight/spec-golang/auth/dao"
 	"github.com/TempleEight/spec-golang/auth/utils"
 	valid "github.com/asaskevich/govalidator"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/mux"
 )
 
@@ -38,5 +42,58 @@ func main() {
 }
 
 func authCreateHandler(w http.ResponseWriter, r *http.Request) {
-	json.NewEncoder(w).Encode(struct{}{})
+	var req authDAO.AuthCreateRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	_, err = valid.ValidateStruct(req)
+	if err != nil {
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	// Hash and salt the password before storing
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Could not hash password: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	req.Password = string(hashedPassword)
+	err = dao.CreateAuth(req)
+	if err != nil {
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	accessToken, err := createToken(req.Email, "TODO", "TODO")
+	if err != nil {
+		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Could not create access token: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	response := authDAO.AuthCreateResponse{
+		AccessToken: accessToken,
+	}
+	json.NewEncoder(w).Encode(response)
+
+}
+
+// Create an access token with a 24 hour lifetime
+func createToken(email string, issuer string, key string) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"email": email,
+		"iss":   issuer,
+		"exp":   time.Now().Add(24 * time.Hour).Unix(),
+	})
+
+	return token.SignedString([]byte(key))
 }

--- a/auth/dao/auth-dao.go
+++ b/auth/dao/auth-dao.go
@@ -46,6 +46,6 @@ func executeQuery(db *sql.DB, query string, args ...interface{}) (int64, error) 
 }
 
 func (dao *DAO) CreateAuth(request AuthCreateRequest) error {
-	_, err := executeQuery(dao.DB, "INSERT INTO auth (email, password) VALUES ($1, $2) RETURNING *", request.Email, request.Password)
+	_, err := executeQuery(dao.DB, "INSERT INTO auth (email, password) VALUES ($1, $2)", request.Email, request.Password)
 	return err
 }

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -4,6 +4,8 @@ go 1.13
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/gorilla/mux v1.7.4
 	github.com/lib/pq v1.3.0
+	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d // indirect
 )

--- a/auth/go.sum
+++ b/auth/go.sum
@@ -1,6 +1,15 @@
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d h1:1ZiEyfaQIg3Qh0EoqpwAakHVhecoE5wlSg5GjnafJGw=
+golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/auth/utils/utils.go
+++ b/auth/utils/utils.go
@@ -21,3 +21,12 @@ func GetConfig(filePath string) (*Config, error) {
 	return &config, nil
 }
 
+// CreateErrorJSON returns a JSON string containing the key error associated with provided value
+func CreateErrorJSON(message string) string {
+	payload := map[string]string{"error": message}
+	json, err := json.Marshal(payload)
+	if err != nil {
+		return err.Error()
+	}
+	return string(json)
+}


### PR DESCRIPTION
The first endpoint I'm creating is one for **creating** a new auth. You provide a email and password, and it should give you back a JWT, valid for 24 hours, associated with your email address. 

There's quite a lot of things that are *not* included yet - I'm aware of that - namely:
- The issuer and secret token (these will be derived from *Kong* - more to come on that)
- Refresh tokens
- Storing a "blacklist" of invalid JWTs
- The minor issue of it not being HTTPS 😉 

### Testing
Build the project in the usual way:
```
❯❯❯ docker-compose up --build
❯❯❯ sh kong/configure-kong.sh 
```

Create a new user:
```
❯❯❯ curl -X POST localhost:8000/api/auth -d '{"email": "jay@me.com", "password": "abcdefgh"}'
{"AccessToken":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpheUBtZS5jb20iLCJleHAiOjE1ODI4MTYzNDIsImlzcyI6IlRPRE8ifQ.D3GbSqOO3_EXe4eW3gDxEIudwhvTZ-2-rp-Utvl1zaM"}
```

Validate the storage:
```
❯❯❯ docker exec -it spec-golang_auth-db_1 sh
...
# psql
...
postgres=# SELECT * FROM auth;
 id |   email    |                           password                           
----+------------+--------------------------------------------------------------
  1 | jay@me.com | $2a$10$7KdOXOKKcJzvy4QSGbL9B.G8iNanOPBC3Er3EY5bVoPFjnIuat1pq
(1 row)
```

Validate the JWT (note the +24 time in `exp`):
<img width="1258" alt="Screenshot 2020-02-26 at 15 14 11" src="https://user-images.githubusercontent.com/16157582/75359032-b060b080-58ab-11ea-8517-b35c5edcc561.png">