### PR TITLE
[auth] Request JWT secret from Kong

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -8,8 +8,10 @@ RUN go mod download
 COPY . .
 COPY config.json /etc/auth-service/
 
+RUN apk add curl
 RUN go build -o auth
+RUN chmod +x wait-for-kong.sh
 
-ENTRYPOINT ./auth
+CMD ["./wait-for-kong.sh", "kong:8001", "--", "./auth"]
 
 EXPOSE 82

--- a/auth/comm/handler.go
+++ b/auth/comm/handler.go
@@ -42,7 +42,7 @@ func createKongConsumer(hostname string) (*consumerResponse, error) {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != 201 {
+	if res.StatusCode != http.StatusCreated {
 		// If we have an error code, the message _should_ be in the body
 		bodyBytes, err := ioutil.ReadAll(res.Body)
 		if err != nil {
@@ -68,7 +68,7 @@ func requestCredential(hostname string, consumer *consumerResponse) (*JWTCredent
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != 201 {
+	if res.StatusCode != http.StatusCreated {
 		// If we have an error code, the message _should_ be in the body
 		bodyBytes, err := ioutil.ReadAll(res.Body)
 		if err != nil {

--- a/auth/comm/handler.go
+++ b/auth/comm/handler.go
@@ -1,0 +1,104 @@
+package comm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/TempleEight/spec-golang/auth/utils"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// Handler maintains the list of services and their associated hostnames
+type Handler struct {
+	Services map[string]string
+}
+
+// consumerResponse encapsulates the response from Kong after creating a consumer
+type consumerResponse struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+}
+
+// JWTCredential store the issuer and secret key that must be used to sign requests
+type JWTCredential struct {
+	Key    string `json:"key"`
+	Secret string `json:"secret"`
+}
+
+// Init sets up the Handler object with a list of services from the config
+func (coms *Handler) Init(config *utils.Config) {
+	coms.Services = config.Services
+}
+
+func createKongConsumer(hostname string) (*consumerResponse, error) {
+	postData := url.Values{}
+	postData.Set("username", "auth-service")
+
+	res, err := http.PostForm(fmt.Sprintf("%s/consumers", hostname), postData)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 201 {
+		// If we have an error code, the message _should_ be in the body
+		bodyBytes, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return nil, errors.New("unable to create JWT consumer")
+		}
+		return nil, errors.New(string(bodyBytes))
+	}
+
+	consumer := consumerResponse{}
+	err = json.NewDecoder(res.Body).Decode(&consumer)
+	if err != nil {
+		return nil, err
+	}
+
+	return &consumer, nil
+}
+
+func requestCredential(hostname string, consumer *consumerResponse) (*JWTCredential, error) {
+	reqUrl := fmt.Sprintf("%s/consumers/%s/jwt", hostname, consumer.Username)
+	res, err := http.Post(reqUrl, "application/x-www-form-urlencoded", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 201 {
+		// If we have an error code, the message _should_ be in the body
+		bodyBytes, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return nil, errors.New("unable to create JWT token")
+		}
+		return nil, errors.New(string(bodyBytes))
+	}
+
+	jwt := JWTCredential{}
+	err = json.NewDecoder(res.Body).Decode(&jwt)
+	if err != nil {
+		return nil, err
+	}
+
+	return &jwt, nil
+}
+
+// CreateJWTCredential provisions a new HS256 JWT credential
+func (coms *Handler) CreateJWTCredential() (*JWTCredential, error) {
+	hostname, ok := coms.Services["kong-admin"]
+	if !ok {
+		return nil, fmt.Errorf("service %s's hostname not in config file", "kong-admin")
+	}
+
+	// Create a consumer
+	consumer, err := createKongConsumer(hostname)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use the consumer to request a credential
+	return requestCredential(hostname, consumer)
+}

--- a/auth/config.json
+++ b/auth/config.json
@@ -3,5 +3,7 @@
   "dbName": "postgres",
   "host": "auth-db",
   "sslMode": "disable",
-  "services": {}
+  "services": {
+    "kong-admin": "http://kong:8001"
+  }
 }

--- a/auth/wait-for-kong.sh
+++ b/auth/wait-for-kong.sh
@@ -8,7 +8,7 @@ shift
 cmd="$@"
 
 until curl $host 2>&1 1>/dev/null; do
-  echo "Kong is unavailable - sleeping"
+  >&2 echo "Kong is unavailable - sleeping"
   sleep 1
 done
 

--- a/auth/wait-for-kong.sh
+++ b/auth/wait-for-kong.sh
@@ -8,7 +8,7 @@ shift
 cmd="$@"
 
 until curl $host 2>&1 1>/dev/null; do
-  >&2 echo "Kong is unavailable - sleeping"
+  echo "Kong is unavailable - sleeping"
   sleep 1
 done
 

--- a/auth/wait-for-kong.sh
+++ b/auth/wait-for-kong.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# https://docs.docker.com/compose/startup-order/
+
+set -e
+
+host="$1"
+shift
+cmd="$@"
+
+until curl $host 2>&1 1>/dev/null; do
+  >&2 echo "Kong is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "Kong is up - starting service"
+exec $cmd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
 
   auth:
     build: ./auth
+    depends_on:
+      - kong
     ports:
       - "82:82"
     networks:

--- a/kong/configure-kong.sh
+++ b/kong/configure-kong.sh
@@ -36,3 +36,10 @@ curl -i -X POST \
   --data 'hosts[]=localhost:8000' \
   --data 'paths[]=/api/auth'
 
+# Require a JWT for the user service
+curl -X POST http://localhost:8001/services/user-service/plugins \
+    --data "name=jwt"
+
+# Require a JWT for the match service
+curl -X POST http://localhost:8001/services/match-service/plugins \
+    --data "name=jwt"


### PR DESCRIPTION
Rather than managing secret keys to sign JWTs ourselves, we can leverage additional Kong functionality. This has several advantages:
- Kong will automatically require and validate JWTs before calling any other service
- Kong controls the secure stuff, so we don't have to
- Less code ❤️ 

So... to do this, the Auth service has to do several things (followed from https://docs.konghq.com/hub/kong-inc/jwt/)
- Register as a "consumer"
- Use this registration to request a secret & key to sign JWTs with

To do this, the auth service requires access to Kong's "Admin" port, exposed on 8001. This would normally _not_ be exposed to the general public, however we currently have it configured that way for ease of testing / configuration.

One issue we now have is that the auth service depends on the Kong service already being ready and active. This **isn't** possible from the Docker Compose `depends-on`(https://docs.docker.com/compose/compose-file/#depends_on), so we are forced to use a shell script that periodically checks for readiness, following the advice from https://docs.docker.com/compose/startup-order/. 

### Test Plan
First spin up all the containers and configure Kong:
```
 ❯❯❯ docker-compose up --build  
 ❯❯❯ sh kong/configure-kong.sh
```

Now try and make a request to a service that isn't auth:
```
❯❯❯ curl -X GET localhost:8000/api/user/2
{"message":"Unauthorized"}
```

Now create a new user:
```
❯❯❯ curl -X POST localhost:8000/api/auth -d '{"email":"jay@test.com", "password":"abcdefgh"}'
{"AccessToken":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpheUB0ZXN0LmNvbSIsImV4cCI6MTU4Mjg5MzU3NywiaXNzIjoiMG9kVHc1d1FXOHRVdlUxVEM5elQxa2pjNnpKQVM1RVYifQ.s89vHXXsZ2xpiCdMGtpABcRA6kbCIlgCWxV3v9SekAI"}
```

Now make the same request as before, including the token in the headers - it works 😍 
```
❯❯❯ curl -X GET localhost:8000/api/user/2 -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpheUB0ZXN0LmNvbSIsImV4cCI6MTU4Mjg5MzU3NywiaXNzIjoiMG9kVHc1d1FXOHRVdlUxVEM5elQxa2pjNnpKQVM1RVYifQ.s89vHXXsZ2xpiCdMGtpABcRA6kbCIlgCWxV3v9SekAI"
{"error":"user not found with ID 2"}
```

Now to make sure this is actually checking the JWT correctly, I've created two JWTs using the debugger at [jwt.io](jwt.io) - one that contains the correct `iss` tag for the `auth-service`, but incorrect signature, and one with random contents:

#### Correct `iss`, incorrect signature
```
❯❯❯ curl -X GET localhost:8000/api/user/2 -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiIwb2RUdzV3UVc4dFV2VTFUQzl6VDFramM2ekpBUzVFViJ9.1bliwzt-ZllhodP0anzB94htvuFsDcykhzeuV_jRlNE"
{"message":"Invalid signature"}
```
<img width="1228" alt="Screenshot 2020-02-27 at 12 45 12" src="https://user-images.githubusercontent.com/16157582/75446319-178b6d00-595f-11ea-8212-e969f8e424aa.png">

#### Random Contents:
```
 ❯❯❯ curl -X GET localhost:8000/api/user/2 -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJSQU5ET01QRVJTT04ifQ._Nv1aKd18JqKf6JVIeUd2-IWNFlPF2pURGRdN19UI1Y"
{"message":"No credentials found for given 'iss'"}
```
<img width="1209" alt="Screenshot 2020-02-27 at 12 43 24" src="https://user-images.githubusercontent.com/16157582/75446332-1b1ef400-595f-11ea-880c-37d861063475.png">



