### PR TITLE
[k8s] Kong Kubernetes Infrastructure

### DIFF
--- a/K8s-DEPLOYMENT.md
+++ b/K8s-DEPLOYMENT.md
@@ -6,7 +6,7 @@ To deploy this project onto a kubernetes cluster follow these steps:
 
 First, a Kubernetes cluster is required to deploy to. Instructions aren't provided here for production ready clusters, see the [Kubernetes Documentation](https://kubernetes.io/docs/tasks/) for that. 
 
-For local development, it's reccomended to use [Minikube](https://github.com/kubernetes/minikube). Follow the instructions to get it set up.
+For local development, it's recommended to use [Minikube](https://github.com/kubernetes/minikube). Follow the instructions to get it set up.
 
 You can start the minikube deaemon with: `minikube start --vm-driver=virtualbox` (assuming you're using the virtualbox backend).
 
@@ -45,3 +45,14 @@ As an example, to deploy all kong infrastructure:
 ```
 kubectl create -f kube/kong
 ```
+
+### Cleaning up
+
+Once done, clean up the cluster by running
+
+```
+minikube delete
+```
+
+
+This will remove all traces of the cluster from your computer.

--- a/K8s-DEPLOYMENT.md
+++ b/K8s-DEPLOYMENT.md
@@ -1,0 +1,41 @@
+# Kubernetes Deployment
+
+To deploy this project onto a kubernetes cluster follow these steps:
+
+## Cluster setup
+
+First, a Kubernetes cluster is required to deploy to. Instructions aren't provided here for production ready clusters, see the [Kubernetes Documentation](https://kubernetes.io/docs/tasks/) for that. 
+
+For local development, it's reccomended to use [Minikube](https://github.com/kubernetes/minikube). Follow the instructions to get it set up.
+
+You can start the minikube deaemon with: `minikube start --vm-driver=virtualbox` (assuming you're using the virtualbox backend).
+
+## Provisioning
+
+The rest of the steps depend on having [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed
+
+### Secrets provision
+
+Some of the containers used in the cluster depend on images in the private Temple docker registry. Kubernetes must be configured with the correct authentication secrets in order to access them.
+
+Run:
+
+```
+kubectl create secret docker-registry regcred --docker-server=$REG_URL --docker-username=$REG_USERNAME --docker-password=$REG_PASSWORD --docker-email=$EMAIL
+```
+
+Replacing `$REG_URL`, `$REG_USERNAME`, `$REG_PASSWORD`, and `$EMAIL` with the correct values.
+
+This creates the `regcred` secret, used to authenticate k8s with the registry.
+
+### Deploying Infrastructure
+
+All of the Kubernetes configuration YAML files are stored in the `/kube` directory.
+
+Running:
+
+```
+kubectl create -f kube
+```
+
+Will provision all of the resources described there.

--- a/K8s-DEPLOYMENT.md
+++ b/K8s-DEPLOYMENT.md
@@ -35,7 +35,13 @@ All of the Kubernetes configuration YAML files are stored in the `/kube` directo
 Running:
 
 ```
-kubectl create -f kube
+kubectl create -f kube/{DIR}
 ```
 
-Will provision all of the resources described there.
+Will provision all of the resources described in that directory, so run that command for each subsection of infra you want to provision.
+
+As an example, to deploy all kong infrastructure:
+
+```
+kubectl create -f kube/kong
+```

--- a/kube/kong/kong-db-deployment.yaml
+++ b/kube/kong/kong-db-deployment.yaml
@@ -1,0 +1,40 @@
+# Deployment to manage Kong Postgres
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kong-db
+  name: kong-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kong-db
+  template:
+    metadata:
+      labels:
+        app: kong-db
+    spec:
+      containers:
+      - env:
+        - name: POSTGRES_DB
+          value: kong
+        - name: POSTGRES_PASSWORD
+          value: kong
+        - name: POSTGRES_USER
+          value: kong
+        image: postgres:12.1
+        ports:
+        - containerPort: 5432
+        livenessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - kong
+          failureThreshold: 3
+          periodSeconds: 30
+          timeoutSeconds: 30
+        name: kong-db
+        stdin: true
+        tty: true

--- a/kube/kong/kong-db-service.yaml
+++ b/kube/kong/kong-db-service.yaml
@@ -1,0 +1,14 @@
+# Service to expose the kong-db to the kong pod
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kong-db
+  name: kong-db
+spec:
+  ports:
+  - name: "database"
+    port: 5432
+    targetPort: 5432
+  selector:
+    app: kong-db

--- a/kube/kong/kong-db-service.yaml
+++ b/kube/kong/kong-db-service.yaml
@@ -6,6 +6,7 @@ metadata:
     app: kong-db
   name: kong-db
 spec:
+  # Exposes an internal NodePort service for communicating within the cluster
   ports:
   - name: "database"
     port: 5432

--- a/kube/kong/kong-deployment.yaml
+++ b/kube/kong/kong-deployment.yaml
@@ -1,0 +1,56 @@
+# Deployment for the main Kong container
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kong
+  name: kong
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kong
+  template:
+    metadata:
+      labels:
+        app: kong
+    spec:
+      containers:
+      - env:
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: /dev/stdout
+        - name: KONG_ADMIN_ERROR_LOG
+          value: /dev/stderr
+        - name: KONG_ADMIN_LISTEN
+          value: 0.0.0.0:8001
+        - name: KONG_CASSANDRA_CONTACT_POINTS
+          value: kong-db
+        - name: KONG_DATABASE
+          value: postgres
+        - name: KONG_PG_DATABASE
+          value: kong
+        - name: KONG_PG_HOST
+          value: kong-db
+        - name: KONG_PG_PASSWORD
+          value: kong
+        - name: KONG_PG_USER
+          value: kong
+        - name: KONG_PROXY_ACCESS_LOG
+          value: /dev/stdout
+        - name: KONG_PROXY_ERROR_LOG
+          value: /dev/stderr
+        image: kong:2.0.1
+        livenessProbe:
+          exec:
+            command:
+            - kong
+            - health
+          failureThreshold: 10
+          periodSeconds: 10
+          timeoutSeconds: 10
+        name: kong
+        ports:
+        - containerPort: 8000
+        - containerPort: 8001
+        - containerPort: 8443
+        - containerPort: 8444

--- a/kube/kong/kong-migration-job.yaml
+++ b/kube/kong/kong-migration-job.yaml
@@ -1,0 +1,27 @@
+# Job that runs once on container startup and performs database migrations on kong-db
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kong-migration
+  labels:
+    app: kong-db
+spec:
+  template:
+    spec:
+      containers:
+      - command: ["/bin/sh"]
+        args: ["-c", "kong migrations bootstrap && kong migrations up && kong migrations finish"]
+        env:
+        - name: KONG_DATABASE
+          value: postgres
+        - name: KONG_PG_DATABASE
+          value: kong
+        - name: KONG_PG_HOST
+          value: kong-db
+        - name: KONG_PG_PASSWORD
+          value: kong
+        - name: KONG_PG_USER
+          value: kong
+        image: kong:2.0.1
+        name: kong-migrations
+      restartPolicy: OnFailure

--- a/kube/kong/kong-service.yaml
+++ b/kube/kong/kong-service.yaml
@@ -1,0 +1,30 @@
+# Service that exposes kong to outside world
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kong
+  name: kong
+spec:
+  type: NodePort
+  ports:
+  - name: "ingress"
+    port: 8000
+    targetPort: 8000
+    # Kubernetes exposes a certain subset of ports externally through nodePorts
+    # Starting at 30000
+    nodePort: 30000
+  - name: "admin"
+    port: 8001
+    targetPort: 8001
+    nodePort: 30001
+  - name: "ingress-tls"
+    port: 8443
+    targetPort: 8443
+    nodePort: 30443
+  - name: "admin-tls"
+    port: 8444
+    targetPort: 8444
+    nodePort: 30444
+  selector:
+    app: kong


### PR DESCRIPTION
This PR adds the configuration required to deploy Kong in Kubernetes.

It's the first of several which will bring all of our Golang spec project into kube. 

It consists of several yaml files, each of which describe a required component of the k8s infra.

[This guide](https://kubernetes.io/docs/concepts/) may be helpful if you don't know anything about Kube.

### Test Plan

The `K8S-DEPLOYMENT.md` file specifies the steps needed to setup your environment to run the tests described here.

Once everything is running:

* Fetch the URLs into the service Minikube has assigned
```
minikube service kong --url
```

* Put these URLS and Port numbers into the `kong/configure-kong.sh` file

* Run the configure script

* Requests to configure the endpoints should succeed (Though pinging the endpoints will fail as the actual services don't exist yet)
