### PR TITLE
[auth] validate exp claim via Kong

### DIFF
--- a/kong/configure-kong.sh
+++ b/kong/configure-kong.sh
@@ -38,8 +38,10 @@ curl -i -X POST \
 
 # Require a JWT for the user service
 curl -X POST http://localhost:8001/services/user-service/plugins \
-    --data "name=jwt"
+    --data "name=jwt"\
+    --data "config.claims_to_verify=exp"
 
 # Require a JWT for the match service
 curl -X POST http://localhost:8001/services/match-service/plugins \
-    --data "name=jwt"
+    --data "name=jwt"\
+    --data "config.claims_to_verify=exp"


### PR DESCRIPTION
Currently Kong validates the `iss` claim in the JWT body, ensuring that it matches a known Kong issuer. It also uses this to validate the signature by looking up the associated public key with the `iss` identifier. 

In addition to this, it makes sense to validate the `exp` claim, which validates when the token expires, before it reaches any sub-service.

This PR adds that functionality.

#### Test Plan
This is a little hard to test at present, since the token expiry is 24 hours. However, changing the following line:

https://github.com/TempleEight/spec-golang/blob/02b773b45e73767d7d3c729a094bb9c631979436/auth/auth.go#L158

to `"exp":   time.Now().Add(0 * time.Hour).Unix(),` will cause the token to immediately be invalidated. 

This can be validated through:
```
❯❯❯ docker-compose up --build 
❯❯❯ sh kong/configure-kong.sh 
```

```
❯❯❯ curl -X POST localhost:8000/api/auth -d '{"email":"jay@test.com", "password":"abcdefgh"}'
{"AccessToken":"$TOKEN"}

❯❯❯ curl -X GET localhost:8000/api/user/1 -H 'Authorization: Bearer $TOKEN'
{"exp":"token expired"}
```