### PR TITLE
[auth] replaces email address in JWT with unique ID

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -81,14 +81,14 @@ func authCreateHandler(w http.ResponseWriter, r *http.Request) {
 		Email:    req.Email,
 		Password: string(hashedPassword),
 	}
-	err = dao.CreateAuth(hashedAuth)
+	auth, err := dao.CreateAuth(hashedAuth)
 	if err != nil {
 		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
 		return
 	}
 
-	accessToken, err := createToken(req.Email, jwtCredential.Key, jwtCredential.Secret)
+	accessToken, err := createToken(auth.Id, jwtCredential.Key, jwtCredential.Secret)
 	if err != nil {
 		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Could not create access token: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -137,7 +137,7 @@ func authReadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	accessToken, err := createToken(req.Email, jwtCredential.Key, jwtCredential.Secret)
+	accessToken, err := createToken(auth.Id, jwtCredential.Key, jwtCredential.Secret)
 	if err != nil {
 		errMsg := utils.CreateErrorJSON(fmt.Sprintf("Could not create access token: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -151,11 +151,11 @@ func authReadHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // Create an access token with a 24 hour lifetime
-func createToken(email string, issuer string, secret string) (string, error) {
+func createToken(id string, issuer string, secret string) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"email": email,
-		"iss":   issuer,
-		"exp":   time.Now().Add(24 * time.Hour).Unix(),
+		"id":  id,
+		"iss": issuer,
+		"exp": time.Now().Add(24 * time.Hour).Unix(),
 	})
 
 	return token.SignedString([]byte(secret))

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -151,7 +151,7 @@ func authReadHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // Create an access token with a 24 hour lifetime
-func createToken(id string, issuer string, secret string) (string, error) {
+func createToken(id int, issuer string, secret string) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"id":  id,
 		"iss": issuer,

--- a/auth/dao/auth-dao.go
+++ b/auth/dao/auth-dao.go
@@ -38,7 +38,7 @@ type AuthReadResponse struct {
 
 // Auth contains the full information persisted in the datastore
 type Auth struct {
-	Id       string
+	Id       int
 	Email    string
 	Password string
 }

--- a/auth/dao/auth-dao.go
+++ b/auth/dao/auth-dao.go
@@ -36,6 +36,13 @@ type AuthReadResponse struct {
 	AccessToken string
 }
 
+// Auth contains the full information persisted in the datastore
+type Auth struct {
+	Id       string
+	Email    string
+	Password string
+}
+
 // Init constructs a DAO from a configuration file
 func (dao *DAO) Init(config *utils.Config) error {
 	connStr := fmt.Sprintf("user=%s dbname=%s host=%s sslmode=%s", config.User, config.DBName, config.Host, config.SSLMode)
@@ -63,16 +70,27 @@ func executeQueryWithRowResponse(db *sql.DB, query string, args ...interface{}) 
 }
 
 // CreateAuth persists a new auth'd user to the data store
-func (dao *DAO) CreateAuth(request AuthCreateRequest) error {
-	_, err := executeQuery(dao.DB, "INSERT INTO auth (email, password) VALUES ($1, $2)", request.Email, request.Password)
-	return err
+func (dao *DAO) CreateAuth(request AuthCreateRequest) (*Auth, error) {
+	row, err := executeQueryWithRowResponse(dao.DB, "INSERT INTO auth (email, password) VALUES ($1, $2) RETURNING *", request.Email, request.Password)
+	var auth Auth
+	err = row.Scan(&auth.Id, &auth.Email, &auth.Password)
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			return nil, ErrAuthNotFound
+		default:
+			return nil, err
+		}
+	}
+
+	return &auth, nil
 }
 
 // ReadAuth attempts to find an existing auth'd user in the data store
-func (dao *DAO) ReadAuth(request AuthReadRequest) (*AuthReadRequest, error) {
-	row, err := executeQueryWithRowResponse(dao.DB, "SELECT email, password FROM auth WHERE email = $1", request.Email)
-	var auth AuthReadRequest
-	err = row.Scan(&auth.Email, &auth.Password)
+func (dao *DAO) ReadAuth(request AuthReadRequest) (*Auth, error) {
+	row, err := executeQueryWithRowResponse(dao.DB, "SELECT * FROM auth WHERE email = $1", request.Email)
+	var auth Auth
+	err = row.Scan(&auth.Id, &auth.Email, &auth.Password)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:


### PR DESCRIPTION
Replace the `email` in the JWT with the ID instead. This will be used to associate all other data with a given auth in the `user` and `match` services.

#### Test Plan

Build in the usual way
```
❯❯❯ docker-compose up --build
❯❯❯ sh kong/configure-kong.sh
```

Create a new user:
```
❯❯❯ curl -X POST localhost:8000/api/auth -d '{"email":"jay@test.com", "password":"abcdefgh"}'
{"AccessToken":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1ODMyNTc5NzcsImlkIjoiMSIsImlzcyI6ImZGUzhLbVZZdUtBQ3lGM3dkcFBLSFNRcW1aVlZ3akRxIn0.PBzvqcvyPEMwaikxZ98dbNrW-zuT7tFUuep0oLB1Arc"}
```

Validate the token on [jwt.io](jwt.io):
<img width="1211" alt="Screenshot 2020-03-02 at 17 53 43" src="https://user-images.githubusercontent.com/16157582/75703161-ceb11c80-5cae-11ea-8b4e-a72bd08dbbd2.png">


Get an existing user:
```
❯❯❯ curl -X GET localhost:8000/api/auth -d '{"email":"jay@test.com", "password":"abcdefgh"}'
{"AccessToken":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1ODMyNTgwNDAsImlkIjoiMSIsImlzcyI6ImZGUzhLbVZZdUtBQ3lGM3dkcFBLSFNRcW1aVlZ3akRxIn0.n9OZ25o8aYQfKEIgSWsBeQBcubusQ3JOOkOg9KFl4L4"}
```

Validate the token on [jwt.io](jwt.io)
<img width="1223" alt="Screenshot 2020-03-02 at 17 54 08" src="https://user-images.githubusercontent.com/16157582/75703179-db357500-5cae-11ea-80ee-edcbef53e25c.png">


NB: This will need some modifications after #29 is merged