### PR TITLE
[user] Generalise database types to allow for dependency injection

### DIFF
--- a/user/dao/dao.go
+++ b/user/dao/dao.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/lib/pq"
 )
 
+// Datastore provides the interface adopted by the DAO, allowing for mocking
 type Datastore interface {
 	CreateUser(request UserCreateRequest) (*UserCreateResponse, error)
 	ReadUser(userID int64) (*UserReadResponse, error)

--- a/user/dao/dao.go
+++ b/user/dao/dao.go
@@ -9,6 +9,13 @@ import (
 	_ "github.com/lib/pq"
 )
 
+type Datastore interface {
+	CreateUser(request UserCreateRequest) (*UserCreateResponse, error)
+	ReadUser(userID int64) (*UserReadResponse, error)
+	UpdateUser(userID int64, request UserUpdateRequest) (*UserUpdateResponse, error)
+	DeleteUser(userID int64) error
+}
+
 // DAO encapsulates access to the database
 type DAO struct {
 	DB *sql.DB
@@ -58,15 +65,13 @@ func executeQuery(db *sql.DB, query string, args ...interface{}) (int64, error) 
 }
 
 // Init opens the database connection
-func (dao *DAO) Init(config *util.Config) error {
+func Init(config *util.Config) (*DAO, error) {
 	connStr := fmt.Sprintf("user=%s dbname=%s host=%s sslmode=%s", config.User, config.DBName, config.Host, config.SSLMode)
-	var err error
-	dao.DB, err = sql.Open("postgres", connStr)
+	db, err := sql.Open("postgres", connStr)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	return nil
+	return &DAO{db}, nil
 }
 
 // CreateUser creates a new user in the database, returning the newly created user

--- a/user/user.go
+++ b/user/user.go
@@ -7,14 +7,14 @@ import (
 	"log"
 	"net/http"
 
-	userDAO "github.com/TempleEight/spec-golang/user/dao"
+	"github.com/TempleEight/spec-golang/user/dao"
 	"github.com/TempleEight/spec-golang/user/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/gorilla/mux"
 )
 
 type Env struct {
-	dao userDAO.Datastore
+	dao dao.Datastore
 }
 
 func main() {
@@ -29,11 +29,11 @@ func main() {
 		log.Fatal(err)
 	}
 
-	dao, err := userDAO.Init(config)
+	d, err := dao.Init(config)
 	if err != nil {
 		log.Fatal(err)
 	}
-	env := Env{dao}
+	env := Env{d}
 
 	r := mux.NewRouter()
 	r.HandleFunc("/user", env.userCreateHandler).Methods(http.MethodPost)
@@ -54,7 +54,7 @@ func jsonMiddleware(next http.Handler) http.Handler {
 }
 
 func (env *Env) userCreateHandler(w http.ResponseWriter, r *http.Request) {
-	var req userDAO.UserCreateRequest
+	var req dao.UserCreateRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
@@ -88,7 +88,7 @@ func (env *Env) userReadHandler(w http.ResponseWriter, r *http.Request) {
 	user, err := env.dao.ReadUser(userID)
 	if err != nil {
 		switch err.(type) {
-		case userDAO.ErrUserNotFound:
+		case dao.ErrUserNotFound:
 			http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusNotFound)
 		default:
 			errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
@@ -106,7 +106,7 @@ func (env *Env) userUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req userDAO.UserUpdateRequest
+	var req dao.UserUpdateRequest
 	err = json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
@@ -124,7 +124,7 @@ func (env *Env) userUpdateHandler(w http.ResponseWriter, r *http.Request) {
 	resp, err := env.dao.UpdateUser(userID, req)
 	if err != nil {
 		switch err.(type) {
-		case userDAO.ErrUserNotFound:
+		case dao.ErrUserNotFound:
 			http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusNotFound)
 		default:
 			errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
@@ -145,7 +145,7 @@ func (env *Env) userDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	err = env.dao.DeleteUser(userID)
 	if err != nil {
 		switch err.(type) {
-		case userDAO.ErrUserNotFound:
+		case dao.ErrUserNotFound:
 			http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusNotFound)
 		default:
 			errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))


### PR DESCRIPTION
To fully test this service, we need to be a bit more general about the code that's being written.

Now, we define a generic interface `Datastore`, which is implemented by the `DAO` object.
This means the main class can be defined over methods on this datastore, allowing dependency injection for testing.

This shouldn't make any difference to existing functionality, so previous test plans still apply:

```
❯❯❯ docker-compose up --build
❯❯❯ sh kong/configure-kong.sh
```

```
❯❯❯ ACCESS=$(curl -s -X POST localhost:8000/api/auth -d '{"email":"jay@test.com", "password":"abcdefgh"}' | jq -r .AccessToken)
❯❯❯ USER1=$(curl -s -X POST localhost:8000/api/user -d '{"name": "Jay"}' -H "Authorization: Bearer $ACCESS" | jq -r .ID)
❯❯❯ USER2=$(curl -s -X POST localhost:8000/api/user -d '{"name": "Lewis"}' -H "Authorization: Bearer $ACCESS" | jq -r .ID)
❯❯❯ curl -X POST localhost:8000/api/match -d "{\"userone\": $USER1, \"usertwo\": $USER2}" -H "Authorization: Bearer $ACCESS"
```