### PR TITLE
[match] Generalise match datastore using interface

### DIFF
--- a/match/comm/handler.go
+++ b/match/comm/handler.go
@@ -7,14 +7,19 @@ import (
 	"github.com/TempleEight/spec-golang/match/util"
 )
 
+// Comm provides the interface adopted by Handler, allowing for mocking
+type Comm interface {
+	CheckUser(userID int) (bool, error)
+}
+
 // Handler maintains the list of services and their associated hostnames
 type Handler struct {
 	Services map[string]string
 }
 
 // Init sets up the Handler object with a list of services from the config
-func (comm *Handler) Init(config *util.Config) {
-	comm.Services = config.Services
+func Init(config *util.Config) *Handler {
+	return &Handler{config.Services}
 }
 
 // CheckUser makes a request to the target service to check if a user ID exists

--- a/match/dao/dao.go
+++ b/match/dao/dao.go
@@ -9,6 +9,15 @@ import (
 	_ "github.com/lib/pq"
 )
 
+// Datastore provides the interface adopted by the DAO, allowing for mocking
+type Datastore interface {
+	ListMatch() (*MatchListResponse, error)
+	CreateMatch(request MatchCreateRequest) (*MatchCreateResponse, error)
+	ReadMatch(matchID int64) (*MatchReadResponse, error)
+	UpdateMatch(matchID int64, request MatchUpdateRequest) (*MatchUpdateResponse, error)
+	DeleteMatch(matchID int64) error
+}
+
 // DAO encapsulates access to the database
 type DAO struct {
 	DB *sql.DB
@@ -76,15 +85,14 @@ func executeQuery(db *sql.DB, query string, args ...interface{}) (int64, error) 
 }
 
 // Init opens the database connection
-func (dao *DAO) Init(config *util.Config) error {
+func Init(config *util.Config) (*DAO, error) {
 	connStr := fmt.Sprintf("user=%s dbname=%s host=%s sslmode=%s", config.User, config.DBName, config.Host, config.SSLMode)
-	var err error
-	dao.DB, err = sql.Open("postgres", connStr)
+	db, err := sql.Open("postgres", connStr)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return &DAO{db}, nil
 }
 
 // ListMatch returns a list containing every match


### PR DESCRIPTION
Similar to #31, just for the match service and applying the same technique to inter service communication.

Test Plan remains the same:
```
❯❯❯ docker-compose up --build
❯❯❯ sh kong/configure-kong.sh
```

```
❯❯❯ ACCESS=$(curl -s -X POST localhost:8000/api/auth -d '{"email":"jay@test.com", "password":"abcdefgh"}' | jq -r .AccessToken)
❯❯❯ USER1=$(curl -s -X POST localhost:8000/api/user -d '{"name": "Jay"}' -H "Authorization: Bearer $ACCESS" | jq -r .ID)
❯❯❯ USER2=$(curl -s -X POST localhost:8000/api/user -d '{"name": "Lewis"}' -H "Authorization: Bearer $ACCESS" | jq -r .ID)
❯❯❯ curl -X POST localhost:8000/api/match -d "{\"userone\": $USER1, \"usertwo\": $USER2}" -H "Authorization: Bearer $ACCESS"
```