### PR TITLE
[auth] Generalise auth datastore using interface

### DIFF
--- a/auth/comm/handler.go
+++ b/auth/comm/handler.go
@@ -10,6 +10,11 @@ import (
 	"net/url"
 )
 
+// Comm provides the interface adopted by Handler, allowing for mocking
+type Comm interface {
+	CreateJWTCredential() (*JWTCredential, error)
+}
+
 // Handler maintains the list of services and their associated hostnames
 type Handler struct {
 	Services map[string]string
@@ -28,8 +33,8 @@ type JWTCredential struct {
 }
 
 // Init sets up the Handler object with a list of services from the config
-func (coms *Handler) Init(config *utils.Config) {
-	coms.Services = config.Services
+func Init(config *utils.Config) *Handler {
+	return &Handler{config.Services}
 }
 
 func createKongConsumer(hostname string) (*consumerResponse, error) {

--- a/auth/dao/dao.go
+++ b/auth/dao/dao.go
@@ -9,6 +9,12 @@ import (
 	_ "github.com/lib/pq"
 )
 
+// Datastore provides the interface adopted by the DAO, allowing for mocking
+type Datastore interface {
+	CreateAuth(request AuthCreateRequest) (*Auth, error)
+	ReadAuth(request AuthReadRequest) (*Auth, error)
+}
+
 // DAO encapsulates access to the database
 type DAO struct {
 	DB *sql.DB
@@ -44,15 +50,14 @@ type Auth struct {
 }
 
 // Init constructs a DAO from a configuration file
-func (dao *DAO) Init(config *utils.Config) error {
+func Init(config *utils.Config) (*DAO, error) {
 	connStr := fmt.Sprintf("user=%s dbname=%s host=%s sslmode=%s", config.User, config.DBName, config.Host, config.SSLMode)
-	var err error
-	dao.DB, err = sql.Open("postgres", connStr)
+	db, err := sql.Open("postgres", connStr)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return &DAO{db}, nil
 }
 
 // Executes a query, returning the number of rows affected


### PR DESCRIPTION
Similar to #31 and #33, just for the auth service and applying the same technique to inter service communication.

Test Plan remains the same:
```
❯❯❯ docker-compose up --build
❯❯❯ sh kong/configure-kong.sh
```

```
❯❯❯ ACCESS=$(curl -s -X POST localhost:8000/api/auth -d '{"email":"jay@test.com", "password":"abcdefgh"}' | jq -r .AccessToken)
❯❯❯ USER1=$(curl -s -X POST localhost:8000/api/user -d '{"name": "Jay"}' -H "Authorization: Bearer $ACCESS" | jq -r .ID)
❯❯❯ USER2=$(curl -s -X POST localhost:8000/api/user -d '{"name": "Lewis"}' -H "Authorization: Bearer $ACCESS" | jq -r .ID)
❯❯❯ curl -X POST localhost:8000/api/match -d "{\"userone\": $USER1, \"usertwo\": $USER2}" -H "Authorization: Bearer $ACCESS"
```