### PR TITLE
[k8s] Integrate Kong and Services for end to end K8s config

### DIFF
--- a/K8s-DEPLOYMENT.md
+++ b/K8s-DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Kubernetes Deployment
 
-#### _NEW: Automated Deployment!_
+## _NEW:_ Automated Deployment
 _Simply run `source deploy.sh` to do all these steps for you!_
 
 Note: When finished with the cluster, you still need to clean up with

--- a/K8s-DEPLOYMENT.md
+++ b/K8s-DEPLOYMENT.md
@@ -3,6 +3,14 @@
 #### _NEW: Automated Deployment!_
 _Simply run `source deploy.sh` to do all these steps for you!_
 
+Note: When finished with the cluster, you still need to clean up with
+
+```
+$ minikube delete
+```
+
+## Manual Deployment
+
 To deploy this project onto a kubernetes cluster follow these steps:
 
 ## Cluster setup

--- a/K8s-DEPLOYMENT.md
+++ b/K8s-DEPLOYMENT.md
@@ -1,5 +1,8 @@
 # Kubernetes Deployment
 
+> __ NEW: Automated Deployment!  __
+> Simply run `source deploy.sh` to do all these steps for you!
+
 To deploy this project onto a kubernetes cluster follow these steps:
 
 ## Cluster setup

--- a/K8s-DEPLOYMENT.md
+++ b/K8s-DEPLOYMENT.md
@@ -1,7 +1,7 @@
 # Kubernetes Deployment
 
-> __ NEW: Automated Deployment!  __
-> Simply run `source deploy.sh` to do all these steps for you!
+#### _NEW: Automated Deployment!_
+_Simply run `source deploy.sh` to do all these steps for you!_
 
 To deploy this project onto a kubernetes cluster follow these steps:
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,10 +15,11 @@ kubectl create secret docker-registry regcred --docker-server=$REG_URL --docker-
 kubectl create configmap match-db-config --from-file match-db/init.sql -o=yaml
 kubectl create configmap user-db-config --from-file user-db/init.sql -o=yaml
 kubectl create configmap auth-db-config --from-file auth-db/init.sql -o=yaml
-kubectl create -f kube/kong
-kubectl create -f kube/user
-kubectl create -f kube/match
-kubectl create -f kube/auth
+
+for dir in kube/*
+do
+  kubectl create -f $dir
+done
 
 echo $NOCOLOR
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,7 +7,7 @@ NOCOLOR="\033[0m"
 
 minikube start --vm-driver=virtualbox
 
-echo ${GREEN}
+echo $GREEN
 
 kubectl create secret docker-registry regcred --docker-server=$REG_URL --docker-username=$REG_USERNAME --docker-password=$REG_PASSWORD --docker-email=$REG_EMAIL
 kubectl create configmap match-db-config --from-file match-db/init.sql -o=yaml
@@ -18,7 +18,7 @@ kubectl create -f kube/user
 kubectl create -f kube/match
 kubectl create -f kube/auth
 
-echo ${NOCOLOR}
+echo $NOCOLOR
 
 # Kube takes a few seconds to create the objects
 sleep 5
@@ -36,12 +36,12 @@ urls=$(minikube service kong --url | head -n 2)
 export KONG_ENTRY=$(echo $urls | head -n 1 | cut -d '/' -f 3-)
 export KONG_ADMIN=$(echo $urls | tail -n 1)
 
-echo ${BLUE}
+echo $BLUE
 
 echo KONG_ENTRY: $KONG_ENTRY
 echo KONG_ADMIN: $KONG_ADMIN
 
-echo ${NOCOLOR}
+echo $NOCOLOR
 
 echo Configuring Kong...
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,7 @@ minikube start --vm-driver=virtualbox
 
 echo ${GREEN}
 
-kubectl create secret docker-registry regcred --docker-server=$REG_URL --docker-username=$REG_USERNAME --docker-password=$REG_PASSWORD --docker-email=$EMAIL
+kubectl create secret docker-registry regcred --docker-server=$REG_URL --docker-username=$REG_USERNAME --docker-password=$REG_PASSWORD --docker-email=$REG_EMAIL
 kubectl create configmap match-db-config --from-file match-db/init.sql -o=yaml
 kubectl create configmap user-db-config --from-file user-db/init.sql -o=yaml
 kubectl create configmap auth-db-config --from-file auth-db/init.sql -o=yaml

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,10 @@
-#! /bin/bash
+#! /bin/sh
 # Deployment script for kube - generates configmaps from SQL init files and provisions everything
 
 GREEN="\033[1;32m"
 BLUE="\033[1;34m"
+YELLOW="\033[1;33m"
+PURPLE="\033[1;34m"
 NOCOLOR="\033[0m"
 
 minikube start --vm-driver=virtualbox
@@ -41,8 +43,17 @@ echo $BLUE
 echo KONG_ENTRY: $KONG_ENTRY
 echo KONG_ADMIN: $KONG_ADMIN
 
-echo $NOCOLOR
+echo $YELLOW
 
 echo Configuring Kong...
 
+sleep 1
+
 sh kong/configure-kong-k8s.sh
+
+echo $PURPLE
+
+echo
+echo Done!
+
+echo $NOCOLOR

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+# Deployment script for kube - generates configmaps from SQL init files and provisions everything
+
+GREEN="\033[1;32m"
+BLUE="\033[1;34m"
+NOCOLOR="\033[0m"
+
+minikube start --vm-driver=virtualbox
+
+echo ${GREEN}
+
+kubectl create secret docker-registry regcred --docker-server=$REG_URL --docker-username=$REG_USERNAME --docker-password=$REG_PASSWORD --docker-email=$EMAIL
+kubectl create configmap match-db-config --from-file match-db/init.sql -o=yaml
+kubectl create configmap user-db-config --from-file user-db/init.sql -o=yaml
+kubectl create configmap auth-db-config --from-file auth-db/init.sql -o=yaml
+kubectl create -f kube/kong
+kubectl create -f kube/user
+kubectl create -f kube/match
+kubectl create -f kube/auth
+
+echo ${NOCOLOR}
+
+# Kube takes a few seconds to create the objects
+sleep 5
+
+echo Sleeping until pods have started...
+# Until all of the pods have status of either "Running" or "Completed"
+until ! kubectl get pod | awk '{ if (NR != 1) printf $3 "\n" }' | grep -s -q -E "Running|Completed" --invert
+do
+  sleep 1
+done
+
+# Get the URLs Minikube has assigned to the endpoints
+urls=$(minikube service kong --url | head -n 2)
+
+export KONG_ENTRY=$(echo $urls | head -n 1 | cut -d '/' -f 3-)
+export KONG_ADMIN=$(echo $urls | tail -n 1)
+
+echo ${BLUE}
+
+echo KONG_ENTRY: $KONG_ENTRY
+echo KONG_ADMIN: $KONG_ADMIN
+
+echo ${NOCOLOR}
+
+echo Configuring Kong...
+
+sh kong/configure-kong-k8s.sh

--- a/kong/configure-kong-k8s.sh
+++ b/kong/configure-kong-k8s.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Add the user service
+curl -i -X POST \
+  --url $KONG_ADMIN/services/ \
+  --data 'name=user-service' \
+  --data 'url=http://user:80/user'
+
+# Add the match service
+curl -i -X POST \
+  --url $KONG_ADMIN/services/ \
+  --data 'name=match-service' \
+  --data 'url=http://match:81/match'
+
+# Add the auth service
+curl -i -X POST \
+  --url $KONG_ADMIN/services/ \
+  --data 'name=auth-service' \
+  --data 'url=http://auth:82/auth'
+
+# Add a route for user
+curl -i -X POST \
+  --url $KONG_ADMIN/services/user-service/routes \
+  --data "hosts[]=$KONG_ENTRY" \
+  --data 'paths[]=/api/user'
+
+# Add a route for match
+curl -i -X POST \
+  --url $KONG_ADMIN/services/match-service/routes \
+  --data "hosts[]=$KONG_ENTRY" \
+  --data 'paths[]=/api/match'
+
+# Add a route for auth
+curl -i -X POST \
+  --url $KONG_ADMIN/services/auth-service/routes \
+  --data "hosts[]=$KONG_ENTRY" \
+  --data 'paths[]=/api/auth'
+
+# Require a JWT for the user service
+curl -X POST $KONG_ADMIN/services/user-service/plugins \
+    --data "name=jwt"\
+    --data "config.claims_to_verify=exp"
+
+# Require a JWT for the match service
+curl -X POST $KONG_ADMIN/services/match-service/plugins \
+    --data "name=jwt"\
+    --data "config.claims_to_verify=exp"

--- a/kube/auth/auth-db-deployment.yaml
+++ b/kube/auth/auth-db-deployment.yaml
@@ -1,0 +1,52 @@
+# Deployment to manage Postgres instance pods for auth service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: auth
+  name: auth-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: auth
+      kind: db
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: auth
+        kind: db
+      name: auth-db
+    spec:
+      hostname: auth-db
+      containers:
+      - env:
+        - name: PGUSER
+          value: postgres
+        image: postgres:12.1
+        name: auth-db
+        volumeMounts:
+          # Mount the PV claim from the storage file
+        - mountPath: /var/lib/postgresql/data
+          name: auth-db-claim
+          # Mount the SQL script from Config Map
+        - mountPath: /docker-entrypoint-initdb.d/init.sql
+          # subPath allows mounting a single file, not a directory
+          subPath: init.sql
+          name: auth-db-init
+        lifecycle:
+          postStart:
+            exec:
+              # This pod can occasionally fail to start the first time, but still creates files
+              # This causes the init db step to be skipped, so this command manually re-runs it
+              command: ["/bin/sh", "-c", "psql -U postgres -f /docker-entrypoint-initdb.d/init.sql && echo done"]
+      restartPolicy: Always
+      volumes:
+      - name: auth-db-init
+        configMap:
+          name: auth-db-config
+      - name: auth-db-claim
+        persistentVolumeClaim:
+          claimName: auth-db-claim

--- a/kube/auth/auth-db-service.yaml
+++ b/kube/auth/auth-db-service.yaml
@@ -1,0 +1,15 @@
+# Service to expose the auth-db to auth service
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: auth-db
+  name: auth-db
+spec:
+  ports:
+  - name: "db"
+    port: 5432
+    targetPort: 5432
+  selector:
+    app: auth
+    kind: db

--- a/kube/auth/auth-db-storage.yaml
+++ b/kube/auth/auth-db-storage.yaml
@@ -1,0 +1,34 @@
+# Persistent Volume that stored Postgres' data
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: auth-db-volume
+  labels:
+    type: local
+    app: auth-db
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Delete
+  hostPath:
+    path: "/data/auth-db"
+---
+# The claim into the persistent storage used by the pod to store
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    app: auth-db
+  name: auth-db-claim
+spec:
+  accessModes:
+  - ReadWriteMany
+  volumeName: auth-db-volume
+  storageClassName: manual
+  resources:
+    requests:
+      storage: 100Mi

--- a/kube/auth/auth-deployment.yaml
+++ b/kube/auth/auth-deployment.yaml
@@ -1,0 +1,30 @@
+# Deployment to manage auth service pods
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: auth
+  name: auth
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: auth
+      kind: service
+  template:
+    metadata:
+      labels:
+        app: auth
+        kind: service
+      name: auth
+    spec:
+      hostname: auth
+      containers:
+      - image: registry.lewiky.com/temple-auth-service
+        name: auth
+        ports:
+        - containerPort: 82
+      imagePullSecrets:
+        # Use the `regcred` secret to connect to the registry
+      - name: regcred
+      restartPolicy: Always

--- a/kube/auth/auth-service.yaml
+++ b/kube/auth/auth-service.yaml
@@ -1,0 +1,15 @@
+# Auth service that exposes the go endpoint to the cluster
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: auth
+  name: auth
+spec:
+  ports:
+  - name: "api"
+    port: 82
+    targetPort: 82
+  selector:
+    app: auth
+    kind: service

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -1,9 +1,0 @@
-#! /bin/bash
-# Deployment script for kube - generates configmaps from SQL init files and provisions everything
-minikube start --vm-driver=virtualbox
-kubectl create secret docker-registry regcred --docker-server=$REG_URL --docker-username=$REG_USERNAME --docker-password=$REG_PASSWORD --docker-email=$EMAIL
-kubectl create configmap match-db-config --from-file ../match-db/init.sql -o=yaml
-kubectl create configmap user-db-config --from-file ../user-db/init.sql -o=yaml
-kubectl create -f kong
-kubectl create -f user
-kubectl create -f match


### PR DESCRIPTION
The last of the Kubernooties PRs - _Tying everything together_.

This adds the authentication service to kubernetes via the same methods used with the user and match services (literally remove the word 'user' and replace with the word 'auth' - very good for generation)

Also provides an end to end build script that sorts out all of the kong configuration to forward requests to the correct services and sets environment variables for the kubernetes endpoints.

Also this doesn't break any of the docker-compose stuff if you don't feel like running the whole k8s stack for future development.

## Test plan

With Minikube installed as before: 

#### Set environment vars

Set the: 
- `$REG_URL`
- `$REG_USERNAME`
- `$REG_PASSWORD`
- `$REG_EMAIL`

Environment variables as before - (NB: This could be edited out by moving the images to docker-hub?)

Run: 

```
source deploy.sh
```

Wait for this to finish, it'll make sure everything is configured correctly

```
❯❯❯ ACCESS=$(curl -s -X POST $KONG_ENTRY/api/auth -d '{"email":"jay@test.com", "password":"abcdefgh"}' | jq -r .AccessToken)
❯❯❯ USER1=$(curl -s -X POST $KONG_ENTRY/api/user -d '{"name": "Jay"}' -H "Authorization: Bearer $ACCESS" | jq -r .ID)
❯❯❯ USER2=$(curl -s -X POST $KONG_ENTRY/api/user -d '{"name": "Lewis"}' -H "Authorization: Bearer $ACCESS" | jq -r .ID)
❯❯❯ curl -X POST $KONG_ENTRY/api/match -d "{\"userone\": $USER1, \"usertwo\": $USER2}" -H "Authorization: Bearer $ACCESS"
```