### PR TITLE
[API] Add index.html for browser-based docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!-- source: https://github.com/Redocly/redoc/ -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/index.html
+++ b/index.html
@@ -1,21 +1,11 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ReDoc</title>
-    <!-- needed for adaptive design -->
+    <title>Docs: Golang sample project</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
-
-    <!--
-    ReDoc doesn't change outer page styles
-    -->
-    <style>
-        body {
-            margin: 0;
-            padding: 0;
-        }
-    </style>
+    <style> body { margin: 0; padding: 0; } </style>
 </head>
 <body>
 <redoc spec-url='api/spec-golang.openapi.yaml'></redoc>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ReDoc</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+        }
+    </style>
+</head>
+<body>
+<redoc spec-url='api/spec-golang.openapi.yaml'></redoc>
+<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+</body>
+</html>


### PR DESCRIPTION
Nice and simple, just a way of viewing the OpenAPI docs. Here’s a simple command for opening the docs in your browser, during local development:

```bash
(sleep 1; open http://localhost:8000) & python3 -m http.server 8000 -b127.0.0.1 > /dev/null 2>&1
```