### PR TITLE
[user][test] Add additional unit tests for the user service

### DIFF
--- a/user/user.go
+++ b/user/user.go
@@ -17,6 +17,17 @@ type Env struct {
 	dao dao.Datastore
 }
 
+// Router generates a router for this service
+func Router(env Env) *mux.Router {
+	r := mux.NewRouter()
+	r.HandleFunc("/user", env.userCreateHandler).Methods(http.MethodPost)
+	r.HandleFunc("/user/{id}", env.userReadHandler).Methods(http.MethodGet)
+	r.HandleFunc("/user/{id}", env.userUpdateHandler).Methods(http.MethodPut)
+	r.HandleFunc("/user/{id}", env.userDeleteHandler).Methods(http.MethodDelete)
+	r.Use(jsonMiddleware)
+	return r
+}
+
 func main() {
 	configPtr := flag.String("config", "/etc/user-service/config.json", "configuration filepath")
 	flag.Parse()
@@ -35,13 +46,7 @@ func main() {
 	}
 	env := Env{d}
 
-	r := mux.NewRouter()
-	r.HandleFunc("/user", env.userCreateHandler).Methods(http.MethodPost)
-	r.HandleFunc("/user/{id}", env.userReadHandler).Methods(http.MethodGet)
-	r.HandleFunc("/user/{id}", env.userUpdateHandler).Methods(http.MethodPut)
-	r.HandleFunc("/user/{id}", env.userDeleteHandler).Methods(http.MethodDelete)
-	r.Use(jsonMiddleware)
-
+	r := Router(env)
 	log.Fatal(http.ListenAndServe(":80", r))
 }
 

--- a/user/user.go
+++ b/user/user.go
@@ -46,8 +46,7 @@ func main() {
 	}
 	env := Env{d}
 
-	r := Router(env)
-	log.Fatal(http.ListenAndServe(":80", r))
+	log.Fatal(http.ListenAndServe(":80", Router(env)))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -45,7 +45,7 @@ func (md *MockDAO) UpdateUser(userID int64, request dao.UserUpdateRequest) (*dao
 			md.Users[i].Name = request.Name
 			return &dao.UserUpdateResponse{
 				ID:   user.ID,
-				Name: user.Name,
+				Name: request.Name,
 			}, nil
 		}
 	}
@@ -62,23 +62,24 @@ func (md *MockDAO) DeleteUser(userID int64) error {
 	return dao.ErrUserNotFound(userID)
 }
 
-var mockEnv = Env{
-	&MockDAO{Users: make([]MockUser, 0)},
-}
-
-func makeRequest(method string, url string, body string, handler http.HandlerFunc) (*httptest.ResponseRecorder, error) {
+func makeRequest(env Env, method string, url string, body string) (*httptest.ResponseRecorder, error) {
 	rec := httptest.NewRecorder()
 	req, err := http.NewRequest(method, url, strings.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
-	handler.ServeHTTP(rec, req)
+
+	Router(env).ServeHTTP(rec, req)
 	return rec, nil
 }
 
 // Test that a user can be successfully created
 func TestUserCreateHandlerSucceeds(t *testing.T) {
-	res, err := makeRequest(http.MethodPost, "/user", `{"Name": "Jay"}`, mockEnv.userCreateHandler)
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
@@ -96,7 +97,11 @@ func TestUserCreateHandlerSucceeds(t *testing.T) {
 
 // Test that providing an empty value for the `Name` parameter causes a `StatusBadRequest`
 func TestUserCreateHandlerFailsOnEmptyParameter(t *testing.T) {
-	res, err := makeRequest(http.MethodPost, "/user", `{"Name": ""}`, mockEnv.userCreateHandler)
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": ""}`)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
@@ -108,11 +113,302 @@ func TestUserCreateHandlerFailsOnEmptyParameter(t *testing.T) {
 
 // Test that providing no body to the request causes a `StatusBadRequest`
 func TestUserCreateHandlerFailsOnNoBody(t *testing.T) {
-	res, err := makeRequest(http.MethodPost, "/user", "", mockEnv.userCreateHandler)
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPost, "/user", "")
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
 
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that a user can be successfully created and then read back
+func TestUserReadHandlerSucceeds(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	// Make a user
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
+	if err != nil {
+		t.Fatalf("Could not make POST request: %s", err.Error())
+	}
+
+	// Access that same user
+	res, err := makeRequest(mockEnv, http.MethodGet, "/user/0", "")
+	if err != nil {
+		t.Fatalf("Could not make GET request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusOK {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+
+	received := res.Body.String()
+	expected := `{"ID":0,"Name":"Jay"}`
+	if expected != strings.TrimSuffix(received, "\n") {
+		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
+	}
+}
+
+// Test that providing no ID to the read endpoint fails
+func TestUserReadHandlerFailsOnEmptyID(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodGet, "/user/", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// 404 Not Found, since no route is defined for GET at /user
+	if res.Code != http.StatusNotFound {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that providing an invalid ID to the read endpoint fails
+func TestUserReadHandlerFailsOnNonExistentID(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodGet, "/user/123456", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// 404 Not Found, since no user exists with that given ID
+	if res.Code != http.StatusNotFound {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that providing a string as ID to the read endpoint fails
+func TestUserReadHandlerFailsOnStringID(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodGet, "/user/abcdef", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// Bad request, since we require an integer
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that a user can be successfully created and then updated
+func TestUserUpdateHandlerSucceeds(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	// Make a user
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
+	if err != nil {
+		t.Fatalf("Could not make POST request: %s", err.Error())
+	}
+
+	// Update that same user
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name": "Lewis"}`)
+	if err != nil {
+		t.Fatalf("Could not make PUT request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusOK {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+
+	received := res.Body.String()
+	expected := `{"ID":0,"Name":"Lewis"}`
+	if expected != strings.TrimSuffix(received, "\n") {
+		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
+	}
+}
+
+// Test that providing an empty name to the update endpoint fails
+func TestUserUpdateHandlerFailsOnEmptyName(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	// Make a user
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
+	if err != nil {
+		t.Fatalf("Could not make POST request: %s", err.Error())
+	}
+
+	// Update that same user
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name": ""}`)
+	if err != nil {
+		t.Fatalf("Could not make PUT request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that providing malformed JSON to the update endpoint fails
+func TestUserUpdateHandlerFailsOnInvalidRequestBody(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	// Make a user
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
+	if err != nil {
+		t.Fatalf("Could not make POST request: %s", err.Error())
+	}
+
+	// Update that same user
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name"}`)
+	if err != nil {
+		t.Fatalf("Could not make PUT request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+
+}
+
+// Test that providing no ID to the update endpoint fails
+func TestUserUpdateHandlerFailsOnEmptyID(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// 404 Not Found, since no route is defined for PUT at /user
+	if res.Code != http.StatusNotFound {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that providing an invalid ID to the update endpoint fails
+func TestUserUpdateHandlerFailsOnNonExistentID(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/123456", `{"Name":"Will"}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// 404 Not Found, since no user exists with that given ID
+	if res.Code != http.StatusNotFound {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// // Test that providing a string as ID to the update endpoint fails
+func TestUserUpdateHandlerFailsOnStringID(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/abcdef", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// Bad request, since we require an integer
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that a user can be successfully created and then deleted
+func TestUserDeleteHandlerSucceeds(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	// Make a user
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
+	if err != nil {
+		t.Fatalf("Could not make POST request: %s", err.Error())
+	}
+
+	// Update that same user
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/0", "")
+	if err != nil {
+		t.Fatalf("Could not make DELETE request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusOK {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+
+	received := res.Body.String()
+	expected := `{}`
+	if expected != strings.TrimSuffix(received, "\n") {
+		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
+	}
+}
+
+// Test that providing no ID to the delete endpoint fails
+func TestUserDeleteHandlerFailsOnEmptyID(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// 404 Not Found, since no route is defined for DELETE at /user
+	if res.Code != http.StatusNotFound {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that providing an invalid ID to the delete endpoint fails
+func TestUserDeleteHandlerFailsOnNonExistentID(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/123456", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// 404 Not Found, since no user exists with that given ID
+	if res.Code != http.StatusNotFound {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that providing a string as ID to the delete endpoint fails
+func TestUserDeleteHandlerFailsOnStringID(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/abcdef", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// Bad request, since we require an integer
 	if res.Code != http.StatusBadRequest {
 		t.Errorf("Wrong status code %v", res.Code)
 	}

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -280,7 +280,6 @@ func TestUserUpdateHandlerFailsOnInvalidRequestBody(t *testing.T) {
 	if res.Code != http.StatusBadRequest {
 		t.Errorf("Wrong status code %v", res.Code)
 	}
-
 }
 
 // Test that providing no ID to the update endpoint fails
@@ -317,7 +316,7 @@ func TestUserUpdateHandlerFailsOnNonExistentID(t *testing.T) {
 	}
 }
 
-// // Test that providing a string as ID to the update endpoint fails
+// Test that providing a string as ID to the update endpoint fails
 func TestUserUpdateHandlerFailsOnStringID(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},


### PR DESCRIPTION
In order to use `mux.Vars` we need to use the same router in tests as the main method - I've extracted this into a method to do that...

Tests have 75.6% coverage, the rest is either in `main` or internal server errors:
```
go test -coverprofile=test.html && go tool cover -html=test.html
```