### PR TITLE
[match][test] Add unit test basis for match service

### DIFF
--- a/match/go.sum
+++ b/match/go.sum
@@ -1,5 +1,3 @@
-github.com/TempleEight/spec-golang v0.0.0-20200227165252-9574c524194e h1:Dv4sjHiXFESTRiK7WMwMP+l2IN6bKMjSBiQqCzeSdX8=
-github.com/TempleEight/spec-golang v0.0.0-20200228102702-c2ae87ea10e5 h1:Ufn8c3c8oJUZenp4pM+0KBF7d1CFwjo2OV+LfSXKbgE=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=

--- a/match/match.go
+++ b/match/match.go
@@ -19,6 +19,18 @@ type Env struct {
 	comm comm.Comm
 }
 
+func Router(env Env) *mux.Router {
+	r := mux.NewRouter()
+	// Mux directs to first matching route, i.e. the order matters
+	r.HandleFunc("/match/all", env.matchListHandler).Methods(http.MethodGet)
+	r.HandleFunc("/match", env.matchCreateHandler).Methods(http.MethodPost)
+	r.HandleFunc("/match/{id}", env.matchReadHandler).Methods(http.MethodGet)
+	r.HandleFunc("/match/{id}", env.matchUpdateHandler).Methods(http.MethodPut)
+	r.HandleFunc("/match/{id}", env.matchDeleteHandler).Methods(http.MethodDelete)
+	r.Use(jsonMiddleware)
+	return r
+}
+
 func main() {
 	configPtr := flag.String("config", "/etc/match-service/config.json", "configuration filepath")
 	flag.Parse()
@@ -39,15 +51,7 @@ func main() {
 
 	env := Env{d, c}
 
-	r := mux.NewRouter()
-	// Mux directs to first matching route, i.e. the order matters
-	r.HandleFunc("/match/all", env.matchListHandler).Methods(http.MethodGet)
-	r.HandleFunc("/match", env.matchCreateHandler).Methods(http.MethodPost)
-	r.HandleFunc("/match/{id}", env.matchReadHandler).Methods(http.MethodGet)
-	r.HandleFunc("/match/{id}", env.matchUpdateHandler).Methods(http.MethodPut)
-	r.HandleFunc("/match/{id}", env.matchDeleteHandler).Methods(http.MethodDelete)
-	r.Use(jsonMiddleware)
-
+	r := Router(env)
 	log.Fatal(http.ListenAndServe(":81", r))
 }
 

--- a/match/match.go
+++ b/match/match.go
@@ -51,8 +51,7 @@ func main() {
 
 	env := Env{d, c}
 
-	r := Router(env)
-	log.Fatal(http.ListenAndServe(":81", r))
+	log.Fatal(http.ListenAndServe(":81", Router(env)))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {

--- a/match/match_test.go
+++ b/match/match_test.go
@@ -25,9 +25,9 @@ type MockComm struct {
 }
 
 func (md *MockDAO) ListMatch() (*dao.MatchListResponse, error) {
-	matches := make([]dao.MatchReadResponse, 0)
+	matchList := make([]dao.MatchReadResponse, 0)
 	for _, match := range md.MatchList {
-		matches = append(matches, dao.MatchReadResponse{
+		matchList = append(matchList, dao.MatchReadResponse{
 			ID:        match.ID,
 			UserOne:   match.UserOne,
 			UserTwo:   match.UserTwo,
@@ -36,7 +36,7 @@ func (md *MockDAO) ListMatch() (*dao.MatchListResponse, error) {
 	}
 
 	return &dao.MatchListResponse{
-		MatchList: matches,
+		MatchList: matchList,
 	}, nil
 }
 

--- a/match/match_test.go
+++ b/match/match_test.go
@@ -134,8 +134,25 @@ func TestMatchCreateHandlerSucceeds(t *testing.T) {
 	}
 }
 
-// Test that a match is not created if one user doesn't exist
-func TestMatchCreateHandlerFailsOnOneInvalidUser(t *testing.T) {
+// Test that a match is not created if UserOne doesn't exist
+func TestMatchCreateHandlerFailsOnInvalidUserOne(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{MatchList: make([]MockMatch, 0)},
+		&MockComm{UserIDs: []int{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPost, "/match", `{"UserOne": 123456, "UserTwo": 0}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that a match is not created if UserTwo doesn't exist
+func TestMatchCreateHandlerFailsOnInvalidUserTwo(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{MatchList: make([]MockMatch, 0)},
 		&MockComm{UserIDs: []int{0, 1}},
@@ -151,8 +168,8 @@ func TestMatchCreateHandlerFailsOnOneInvalidUser(t *testing.T) {
 	}
 }
 
-// Test that a match is not created if every user doesn't exist
-func TestMatchCreateHandlerFailsOnEveryUserInvalid(t *testing.T) {
+// Test that a match is not created if every reference doesn't exist
+func TestMatchCreateHandlerFailsOnAllInvalidReferences(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{MatchList: make([]MockMatch, 0)},
 		&MockComm{UserIDs: []int{0, 1}},

--- a/match/match_test.go
+++ b/match/match_test.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/TempleEight/spec-golang/match/dao"
+)
+
+type MockMatch struct {
+	ID        int
+	UserOne   int
+	UserTwo   int
+	MatchedOn string
+}
+
+type MockDAO struct {
+	Matches []MockMatch
+}
+
+type MockComm struct {
+	UserIds []int
+}
+
+func (md *MockDAO) ListMatch() (*dao.MatchListResponse, error) {
+	matches := make([]dao.MatchReadResponse, 0)
+	for _, match := range md.Matches {
+		matches = append(matches, dao.MatchReadResponse{
+			ID:        match.ID,
+			UserOne:   match.UserOne,
+			UserTwo:   match.UserTwo,
+			MatchedOn: match.MatchedOn,
+		})
+	}
+
+	return &dao.MatchListResponse{
+		MatchList: matches,
+	}, nil
+}
+
+func (md *MockDAO) CreateMatch(request dao.MatchCreateRequest) (*dao.MatchCreateResponse, error) {
+	mockMatch := MockMatch{len(md.Matches), *request.UserOne, *request.UserTwo, "2020-01-01T12:00:00.000000Z"}
+	md.Matches = append(md.Matches, mockMatch)
+	return &dao.MatchCreateResponse{
+		ID:        mockMatch.ID,
+		UserOne:   mockMatch.UserOne,
+		UserTwo:   mockMatch.UserTwo,
+		MatchedOn: mockMatch.MatchedOn,
+	}, nil
+}
+
+func (md *MockDAO) ReadMatch(matchID int64) (*dao.MatchReadResponse, error) {
+	for _, match := range md.Matches {
+		if int64(match.ID) == matchID {
+			return &dao.MatchReadResponse{
+				ID:        match.ID,
+				UserOne:   match.UserOne,
+				UserTwo:   match.UserTwo,
+				MatchedOn: match.MatchedOn,
+			}, nil
+		}
+	}
+	return nil, dao.ErrMatchNotFound(matchID)
+}
+
+func (md *MockDAO) UpdateMatch(matchID int64, request dao.MatchUpdateRequest) (*dao.MatchUpdateResponse, error) {
+	for i, match := range md.Matches {
+		if int64(match.ID) == matchID {
+			md.Matches[i].UserOne = *request.UserOne
+			md.Matches[i].UserTwo = *request.UserTwo
+			md.Matches[i].MatchedOn = "2020-12-31T12:00:00.000000Z"
+			return &dao.MatchUpdateResponse{
+				ID:        md.Matches[i].ID,
+				UserOne:   md.Matches[i].UserOne,
+				UserTwo:   md.Matches[i].UserTwo,
+				MatchedOn: md.Matches[i].MatchedOn,
+			}, nil
+		}
+	}
+	return nil, dao.ErrMatchNotFound(matchID)
+}
+
+func (md *MockDAO) DeleteMatch(matchID int64) error {
+	for i, match := range md.Matches {
+		if int64(match.ID) == matchID {
+			md.Matches = append(md.Matches[:i], md.Matches[i+1:]...)
+			return nil
+		}
+	}
+	return dao.ErrMatchNotFound(matchID)
+}
+
+func (mc *MockComm) CheckUser(userID int) (bool, error) {
+	for _, id := range mc.UserIds {
+		if id == userID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func makeRequest(env Env, method string, url string, body string) (*httptest.ResponseRecorder, error) {
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest(method, url, strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	Router(env).ServeHTTP(rec, req)
+	return rec, nil
+}
+
+// Test that a match can be created successfully, assuming the users exist
+func TestMatchCreateHandlerSucceeds(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Matches: make([]MockMatch, 0)},
+		&MockComm{UserIds: []int{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPost, "/match", `{"UserOne": 0, "UserTwo": 1}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusOK {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+
+	received := res.Body.String()
+	expected := `{"ID":0,"UserOne":0,"UserTwo":1,"MatchedOn":"2020-01-01T12:00:00.000000Z"}`
+	if expected != strings.TrimSuffix(received, "\n") {
+		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
+	}
+}
+
+// Test that a match is not created if one of the users doesn't exist
+func TestMatchCreateHandlerFailsOnOneInvalidUser(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Matches: make([]MockMatch, 0)},
+		&MockComm{UserIds: []int{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPost, "/match", `{"UserOne": 0, "UserTwo": 123456}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that a match is not created if both of the users don't exist
+func TestMatchCreateHandlerFailsOnBothInvalidUsers(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Matches: make([]MockMatch, 0)},
+		&MockComm{UserIds: []int{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPost, "/match", `{"UserOne": 123456, "UserTwo": 234567}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+func TestMatchCreateHandlerFailsOnOnlyProvidingOneUser(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Matches: make([]MockMatch, 0)},
+		&MockComm{UserIds: []int{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPost, "/match", `{"UserOne": 123456}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that creating a match fails if the request body is malformed
+func TestMatchCreateHandlerFailsOnMalformedJSONBody(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Matches: make([]MockMatch, 0)},
+		&MockComm{UserIds: []int{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPost, "/match", `{"Use}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}


### PR DESCRIPTION
Add basis for unit tests in match service.

We hit all the cases in `create` except for internal server errors and `govalidator` checks - since there are no conditions on the valiadator
```
go test -coverprofile=test.html && go tool cover -html=test.html
```
