### PR TITLE
[auth][test] Add additional tests for auth

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"golang.org/x/crypto/bcrypt"
 	"log"
 	"net/http"
 	"time"
+
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/TempleEight/spec-golang/auth/comm"
 	"github.com/TempleEight/spec-golang/auth/dao"

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -124,7 +124,7 @@ func TestAuthCreateHandlerSucceeds(t *testing.T) {
 	}
 }
 
-// Test that providing an empty value for the `Email` parameter causes a `StatusBadRequest`
+// Test that providing an empty value for the `email` parameter causes a `StatusBadRequest`
 func TestAuthCreateHandlerFailsOnEmptyParameter(t *testing.T) {
 	mockComm := MockComm{}
 	cred, _ := mockComm.CreateJWTCredential()
@@ -230,7 +230,7 @@ func TestAuthReadHandlerSucceeds(t *testing.T) {
 	}
 }
 
-// Test that providing an empty parameter to the read endpoint fails
+// Test that providing an empty value for the `email` parameter causes a `StatusBadRequest`
 func TestAuthReadHandlerFailsOnEmptyParameter(t *testing.T) {
 	mockComm := MockComm{}
 	cred, _ := mockComm.CreateJWTCredential()
@@ -251,7 +251,7 @@ func TestAuthReadHandlerFailsOnEmptyParameter(t *testing.T) {
 	}
 }
 
-// Test that looking up an auth that doesn't exist fails
+// Test that providing an auth that doesn't exist causes a `StatusUnauthorized`
 func TestAuthReadHandlerFailsOnNonExistentAuth(t *testing.T) {
 	mockComm := MockComm{}
 	cred, _ := mockComm.CreateJWTCredential()
@@ -271,7 +271,7 @@ func TestAuthReadHandlerFailsOnNonExistentAuth(t *testing.T) {
 	}
 }
 
-// Test that providing an invalid json body to the read endpoint fails
+// Test that providing an invalid json body causes a `StatusBadRequest`
 func TestAuthReadHandlerFailsOnMalformedJSON(t *testing.T) {
 	mockComm := MockComm{}
 	cred, _ := mockComm.CreateJWTCredential()

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -123,3 +123,170 @@ func TestAuthCreateHandlerSucceeds(t *testing.T) {
 		t.Fatalf("iss is incorrect: found %v, wanted: %s", iss, cred.Key)
 	}
 }
+
+// Test that providing an empty value for the `Email` parameter causes a `StatusBadRequest`
+func TestAuthCreateHandlerFailsOnEmptyParameter(t *testing.T) {
+	mockComm := MockComm{}
+	cred, _ := mockComm.CreateJWTCredential()
+	mockEnv := Env{
+		&MockDAO{AuthList: make([]MockAuth, 0)},
+		&mockComm,
+		cred,
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPost, "/auth", `{"email": "", "password": "BlackcurrantCrush123"}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that providing no body to the request causes a `StatusBadRequest`
+func TestAuthCreateHandlerFailsOnNoBody(t *testing.T) {
+	mockComm := MockComm{}
+	cred, _ := mockComm.CreateJWTCredential()
+	mockEnv := Env{
+		&MockDAO{AuthList: make([]MockAuth, 0)},
+		&mockComm,
+		cred,
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPost, "/auth", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that an auth can be successfully created and then read from
+func TestAuthReadHandlerSucceeds(t *testing.T) {
+	mockComm := MockComm{}
+	cred, _ := mockComm.CreateJWTCredential()
+	mockEnv := Env{
+		&MockDAO{AuthList: make([]MockAuth, 0)},
+		&mockComm,
+		cred,
+	}
+
+	// Create an auth
+	_, err := makeRequest(mockEnv, http.MethodPost, "/auth", `{"email": "jay@test.com", "password": "BlackcurrantCrush123"}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// Access that same auth
+	res, err := makeRequest(mockEnv, http.MethodGet, "/auth", `{"email": "jay@test.com", "password":"BlackcurrantCrush123"}`)
+	if err != nil {
+		t.Fatalf("Could not make GET request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusOK {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+
+	var decoded map[string]string
+	err = json.Unmarshal([]byte(res.Body.String()), &decoded)
+	if err != nil {
+		t.Fatalf("Could not decode json: %s", err.Error())
+	}
+
+	rawToken, ok := decoded["AccessToken"]
+	if !ok {
+		t.Fatalf("Token doesn't contain an access token: %s", err.Error())
+	}
+
+	token, _, err := new(jwt.Parser).ParseUnverified(rawToken, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("Could not decode JWT: %s", err.Error())
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatalf("Could not decode claims")
+	}
+
+	id, ok := claims["id"]
+	if !ok {
+		t.Fatalf("Claims doesn't contain an ID key")
+	}
+
+	if id.(float64) != 0 {
+		t.Fatalf("ID is incorrect: found %+v, wanted: 0", id)
+	}
+
+	iss, ok := claims["iss"]
+	if !ok {
+		t.Fatalf("Claims doesn't contain an iss key")
+	}
+
+	if iss.(string) != cred.Key {
+		t.Fatalf("iss is incorrect: found %v, wanted: %s", iss, cred.Key)
+	}
+}
+
+// Test that providing an empty parameter to the read endpoint fails
+func TestAuthReadHandlerFailsOnEmptyParameter(t *testing.T) {
+	mockComm := MockComm{}
+	cred, _ := mockComm.CreateJWTCredential()
+	mockEnv := Env{
+		&MockDAO{AuthList: make([]MockAuth, 0)},
+		&mockComm,
+		cred,
+	}
+
+	// Access that same auth
+	res, err := makeRequest(mockEnv, http.MethodGet, "/auth", `{"email": "", "password":"BlackcurrantCrush123"}`)
+	if err != nil {
+		t.Fatalf("Could not make GET request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that looking up an auth that doesn't exist fails
+func TestAuthReadHandlerFailsOnNonExistentAuth(t *testing.T) {
+	mockComm := MockComm{}
+	cred, _ := mockComm.CreateJWTCredential()
+	mockEnv := Env{
+		&MockDAO{AuthList: make([]MockAuth, 0)},
+		&mockComm,
+		cred,
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodGet, "/auth", `{"email": "idonotexist@test.com", "password":"BlackcurrantCrush123"}`)
+	if err != nil {
+		t.Fatalf("Could not make GET request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusUnauthorized {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that providing an invalid json body to the read endpoint fails
+func TestAuthReadHandlerFailsOnMalformedJSON(t *testing.T) {
+	mockComm := MockComm{}
+	cred, _ := mockComm.CreateJWTCredential()
+	mockEnv := Env{
+		&MockDAO{AuthList: make([]MockAuth, 0)},
+		&mockComm,
+		cred,
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodGet, "/auth", `{"email`)
+	if err != nil {
+		t.Fatalf("Could not make GET request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}


### PR DESCRIPTION
I just <3 testing. 

Adds some more tests for the `auth` service. Follows the same structure as those for `user`.

![](https://media.giphy.com/media/r7riLSvkCAgSI/giphy.gif)