### PR TITLE
[user][dao] Move request response types from DAO

### DIFF
--- a/user/dao/dao.go
+++ b/user/dao/dao.go
@@ -11,10 +11,10 @@ import (
 
 // Datastore provides the interface adopted by the DAO, allowing for mocking
 type Datastore interface {
-	CreateUser(request UserCreateRequest) (*UserCreateResponse, error)
-	ReadUser(userID int64) (*UserReadResponse, error)
-	UpdateUser(userID int64, request UserUpdateRequest) (*UserUpdateResponse, error)
-	DeleteUser(userID int64) error
+	CreateUser(input CreateUserInput) (*User, error)
+	ReadUser(input ReadUserInput) (*User, error)
+	UpdateUser(input UpdateUserInput) (*User, error)
+	DeleteUser(input DeleteUserInput) error
 }
 
 // DAO encapsulates access to the database
@@ -22,32 +22,31 @@ type DAO struct {
 	DB *sql.DB
 }
 
-// UserCreateRequest contains the information required to create a new user
-type UserCreateRequest struct {
-	Name string `valid:"type(string),required,stringlength(2|255)"`
-}
-
-// UserUpdateRequest contains all the information about an existing user
-type UserUpdateRequest struct {
-	Name string `valid:"type(string),required,stringlength(2|255)"`
-}
-
-// UserCreateResponse contains the information about the newly created user
-type UserCreateResponse struct {
-	ID   int
+// User encapsulates the object stored in the datastore
+type User struct {
+	ID   int64
 	Name string
 }
 
-// UserReadResponse returns all the information stored about a user
-type UserReadResponse struct {
-	ID   int
+// CreateUserInput encapsulates the information required to create a user
+type CreateUserInput struct {
 	Name string
 }
 
-// UserUpdateResponse contains the information about the newly updated user
-type UserUpdateResponse struct {
-	ID   int
+// ReadUserInput encapsulates the information required to read a user
+type ReadUserInput struct {
+	ID int64
+}
+
+// UpdateUserInput encapsulates the information required to update a user
+type UpdateUserInput struct {
+	ID   int64
 	Name string
+}
+
+// DeleteUserInput encapsulates the information required to delete a user
+type DeleteUserInput struct {
+	ID int64
 }
 
 // Executes the query, returning the row
@@ -76,10 +75,10 @@ func Init(config *util.Config) (*DAO, error) {
 }
 
 // CreateUser creates a new user in the database, returning the newly created user
-func (dao *DAO) CreateUser(request UserCreateRequest) (*UserCreateResponse, error) {
-	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO User_Temple (name) VALUES ($1) RETURNING *", request.Name)
+func (dao *DAO) CreateUser(input CreateUserInput) (*User, error) {
+	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO User_Temple (name) VALUES ($1) RETURNING *", input.Name)
 
-	var resp UserCreateResponse
+	var resp User
 	err := row.Scan(&resp.ID, &resp.Name)
 	if err != nil {
 		return nil, err
@@ -89,15 +88,15 @@ func (dao *DAO) CreateUser(request UserCreateRequest) (*UserCreateResponse, erro
 }
 
 // ReadUser returns the information about a user stored for a given ID
-func (dao *DAO) ReadUser(userID int64) (*UserReadResponse, error) {
-	row := executeQueryWithRowResponse(dao.DB, "SELECT * FROM User_Temple WHERE id = $1", userID)
+func (dao *DAO) ReadUser(input ReadUserInput) (*User, error) {
+	row := executeQueryWithRowResponse(dao.DB, "SELECT * FROM User_Temple WHERE id = $1", input.ID)
 
-	var resp UserReadResponse
+	var resp User
 	err := row.Scan(&resp.ID, &resp.Name)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
-			return nil, ErrUserNotFound(userID)
+			return nil, ErrUserNotFound(input.ID)
 		default:
 			return nil, err
 		}
@@ -107,15 +106,15 @@ func (dao *DAO) ReadUser(userID int64) (*UserReadResponse, error) {
 }
 
 // UpdateUser updates a user in the database, returning an error if it fails
-func (dao *DAO) UpdateUser(userID int64, request UserUpdateRequest) (*UserUpdateResponse, error) {
-	row := executeQueryWithRowResponse(dao.DB, "UPDATE User_Temple set Name = $1 WHERE Id = $2 RETURNING *", request.Name, userID)
+func (dao *DAO) UpdateUser(input UpdateUserInput) (*User, error) {
+	row := executeQueryWithRowResponse(dao.DB, "UPDATE User_Temple set Name = $1 WHERE Id = $2 RETURNING *", input.Name, input.ID)
 
-	var resp UserUpdateResponse
+	var resp User
 	err := row.Scan(&resp.ID, &resp.Name)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
-			return nil, ErrUserNotFound(userID)
+			return nil, ErrUserNotFound(input.ID)
 		default:
 			return nil, err
 		}
@@ -125,12 +124,12 @@ func (dao *DAO) UpdateUser(userID int64, request UserUpdateRequest) (*UserUpdate
 }
 
 // DeleteUser deletes a user in the database, returning an error if it fails or the user doesn't exist
-func (dao *DAO) DeleteUser(userID int64) error {
-	rowsAffected, err := executeQuery(dao.DB, "DELETE FROM User_Temple WHERE Id = $1", userID)
+func (dao *DAO) DeleteUser(input DeleteUserInput) error {
+	rowsAffected, err := executeQuery(dao.DB, "DELETE FROM User_Temple WHERE Id = $1", input.ID)
 	if err != nil {
 		return err
 	} else if rowsAffected == 0 {
-		return ErrUserNotFound(userID)
+		return ErrUserNotFound(input.ID)
 	}
 
 	return nil

--- a/user/dao/dao.go
+++ b/user/dao/dao.go
@@ -78,21 +78,21 @@ func Init(config *util.Config) (*DAO, error) {
 func (dao *DAO) CreateUser(input CreateUserInput) (*User, error) {
 	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO User_Temple (name) VALUES ($1) RETURNING *", input.Name)
 
-	var resp User
-	err := row.Scan(&resp.ID, &resp.Name)
+	var user User
+	err := row.Scan(&user.ID, &user.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	return &resp, nil
+	return &user, nil
 }
 
 // ReadUser returns the information about a user stored for a given ID
 func (dao *DAO) ReadUser(input ReadUserInput) (*User, error) {
 	row := executeQueryWithRowResponse(dao.DB, "SELECT * FROM User_Temple WHERE id = $1", input.ID)
 
-	var resp User
-	err := row.Scan(&resp.ID, &resp.Name)
+	var user User
+	err := row.Scan(&user.ID, &user.Name)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
@@ -102,15 +102,15 @@ func (dao *DAO) ReadUser(input ReadUserInput) (*User, error) {
 		}
 	}
 
-	return &resp, nil
+	return &user, nil
 }
 
 // UpdateUser updates a user in the database, returning an error if it fails
 func (dao *DAO) UpdateUser(input UpdateUserInput) (*User, error) {
 	row := executeQueryWithRowResponse(dao.DB, "UPDATE User_Temple set Name = $1 WHERE Id = $2 RETURNING *", input.Name, input.ID)
 
-	var resp User
-	err := row.Scan(&resp.ID, &resp.Name)
+	var user User
+	err := row.Scan(&user.ID, &user.Name)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
@@ -120,7 +120,7 @@ func (dao *DAO) UpdateUser(input UpdateUserInput) (*User, error) {
 		}
 	}
 
-	return &resp, nil
+	return &user, nil
 }
 
 // DeleteUser deletes a user in the database, returning an error if it fails or the user doesn't exist

--- a/user/dao/dao.go
+++ b/user/dao/dao.go
@@ -28,23 +28,23 @@ type User struct {
 	Name string
 }
 
-// CreateUserInput encapsulates the information required to create a user
+// CreateUserInput encapsulates the information required to create a single user
 type CreateUserInput struct {
 	Name string
 }
 
-// ReadUserInput encapsulates the information required to read a user
+// ReadUserInput encapsulates the information required to read a single user
 type ReadUserInput struct {
 	ID int64
 }
 
-// UpdateUserInput encapsulates the information required to update a user
+// UpdateUserInput encapsulates the information required to update a single user
 type UpdateUserInput struct {
 	ID   int64
 	Name string
 }
 
-// DeleteUserInput encapsulates the information required to delete a user
+// DeleteUserInput encapsulates the information required to delete a single user
 type DeleteUserInput struct {
 	ID int64
 }

--- a/user/user.go
+++ b/user/user.go
@@ -34,7 +34,7 @@ type createUserResponse struct {
 	Name string
 }
 
-// readUserResponse returns all the information stored about a user
+// readUserResponse returns all the information stored about a single user
 type readUserResponse struct {
 	ID   int64
 	Name string

--- a/user/user.go
+++ b/user/user.go
@@ -13,45 +13,46 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// env defines the environment that requests should be executed within
 type env struct {
 	dao dao.Datastore
 }
 
-// UserCreateRequest contains the information required to create a new user
-type userCreateRequest struct {
+// createUserRequest contains the information required to create a new user
+type createUserRequest struct {
 	Name string `valid:"type(string),required,stringlength(2|255)"`
 }
 
-// UserUpdateRequest contains all the information about an existing user
-type userUpdateRequest struct {
+// updateUserRequest contains all the information about an existing user
+type updateUserRequest struct {
 	Name string `valid:"type(string),required,stringlength(2|255)"`
 }
 
-// UserCreateResponse contains the information about the newly created user
-type userCreateResponse struct {
+// createUserResponse contains the information about the newly created user
+type createUserResponse struct {
 	ID   int64
 	Name string
 }
 
-// UserReadResponse returns all the information stored about a user
-type userReadResponse struct {
+// readUserResponse returns all the information stored about a user
+type readUserResponse struct {
 	ID   int64
 	Name string
 }
 
-// UserUpdateResponse contains the information about the newly updated user
-type userUpdateResponse struct {
+// updateUserResponse contains the information about the newly updated user
+type updateUserResponse struct {
 	ID   int64
 	Name string
 }
 
-// Router generates a router for this service
+// router generates a router for this service
 func (env *env) router() *mux.Router {
 	r := mux.NewRouter()
-	r.HandleFunc("/user", env.userCreateHandler).Methods(http.MethodPost)
-	r.HandleFunc("/user/{id}", env.userReadHandler).Methods(http.MethodGet)
-	r.HandleFunc("/user/{id}", env.userUpdateHandler).Methods(http.MethodPut)
-	r.HandleFunc("/user/{id}", env.userDeleteHandler).Methods(http.MethodDelete)
+	r.HandleFunc("/user", env.createUserHandler).Methods(http.MethodPost)
+	r.HandleFunc("/user/{id}", env.readUserHandler).Methods(http.MethodGet)
+	r.HandleFunc("/user/{id}", env.updateUserHandler).Methods(http.MethodPut)
+	r.HandleFunc("/user/{id}", env.deleteUserHandler).Methods(http.MethodDelete)
 	r.Use(jsonMiddleware)
 	return r
 }
@@ -85,8 +86,8 @@ func jsonMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func (env *env) userCreateHandler(w http.ResponseWriter, r *http.Request) {
-	var req userCreateRequest
+func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
+	var req createUserRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
@@ -109,13 +110,13 @@ func (env *env) userCreateHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, errMsg, http.StatusInternalServerError)
 		return
 	}
-	json.NewEncoder(w).Encode(userCreateResponse{
+	json.NewEncoder(w).Encode(createUserResponse{
 		ID:   resp.ID,
 		Name: resp.Name,
 	})
 }
 
-func (env *env) userReadHandler(w http.ResponseWriter, r *http.Request) {
+func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 	userID, err := util.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
 		http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusBadRequest)
@@ -135,20 +136,20 @@ func (env *env) userReadHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	json.NewEncoder(w).Encode(userReadResponse{
+	json.NewEncoder(w).Encode(readUserResponse{
 		ID:   user.ID,
 		Name: user.Name,
 	})
 }
 
-func (env *env) userUpdateHandler(w http.ResponseWriter, r *http.Request) {
+func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 	userID, err := util.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
 		http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusBadRequest)
 		return
 	}
 
-	var req userUpdateRequest
+	var req updateUserRequest
 	err = json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
@@ -178,13 +179,13 @@ func (env *env) userUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	json.NewEncoder(w).Encode(userUpdateResponse{
+	json.NewEncoder(w).Encode(updateUserResponse{
 		ID:   resp.ID,
 		Name: resp.Name,
 	})
 }
 
-func (env *env) userDeleteHandler(w http.ResponseWriter, r *http.Request) {
+func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 	userID, err := util.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
 		http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusBadRequest)

--- a/user/user.go
+++ b/user/user.go
@@ -13,12 +13,40 @@ import (
 	"github.com/gorilla/mux"
 )
 
-type Env struct {
+type env struct {
 	dao dao.Datastore
 }
 
+// UserCreateRequest contains the information required to create a new user
+type userCreateRequest struct {
+	Name string `valid:"type(string),required,stringlength(2|255)"`
+}
+
+// UserUpdateRequest contains all the information about an existing user
+type userUpdateRequest struct {
+	Name string `valid:"type(string),required,stringlength(2|255)"`
+}
+
+// UserCreateResponse contains the information about the newly created user
+type userCreateResponse struct {
+	ID   int64
+	Name string
+}
+
+// UserReadResponse returns all the information stored about a user
+type userReadResponse struct {
+	ID   int64
+	Name string
+}
+
+// UserUpdateResponse contains the information about the newly updated user
+type userUpdateResponse struct {
+	ID   int64
+	Name string
+}
+
 // Router generates a router for this service
-func Router(env Env) *mux.Router {
+func (env *env) router() *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/user", env.userCreateHandler).Methods(http.MethodPost)
 	r.HandleFunc("/user/{id}", env.userReadHandler).Methods(http.MethodGet)
@@ -44,9 +72,9 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	env := Env{d}
+	env := env{d}
 
-	log.Fatal(http.ListenAndServe(":80", Router(env)))
+	log.Fatal(http.ListenAndServe(":80", env.router()))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {
@@ -57,8 +85,8 @@ func jsonMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func (env *Env) userCreateHandler(w http.ResponseWriter, r *http.Request) {
-	var req dao.UserCreateRequest
+func (env *env) userCreateHandler(w http.ResponseWriter, r *http.Request) {
+	var req userCreateRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
@@ -73,23 +101,30 @@ func (env *Env) userCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := env.dao.CreateUser(req)
+	resp, err := env.dao.CreateUser(dao.CreateUserInput{
+		Name: req.Name,
+	})
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
 		return
 	}
-	json.NewEncoder(w).Encode(resp)
+	json.NewEncoder(w).Encode(userCreateResponse{
+		ID:   resp.ID,
+		Name: resp.Name,
+	})
 }
 
-func (env *Env) userReadHandler(w http.ResponseWriter, r *http.Request) {
+func (env *env) userReadHandler(w http.ResponseWriter, r *http.Request) {
 	userID, err := util.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
 		http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusBadRequest)
 		return
 	}
 
-	user, err := env.dao.ReadUser(userID)
+	user, err := env.dao.ReadUser(dao.ReadUserInput{
+		ID: userID,
+	})
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrUserNotFound:
@@ -100,17 +135,20 @@ func (env *Env) userReadHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	json.NewEncoder(w).Encode(user)
+	json.NewEncoder(w).Encode(userReadResponse{
+		ID:   user.ID,
+		Name: user.Name,
+	})
 }
 
-func (env *Env) userUpdateHandler(w http.ResponseWriter, r *http.Request) {
+func (env *env) userUpdateHandler(w http.ResponseWriter, r *http.Request) {
 	userID, err := util.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
 		http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusBadRequest)
 		return
 	}
 
-	var req dao.UserUpdateRequest
+	var req userUpdateRequest
 	err = json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
@@ -125,7 +163,10 @@ func (env *Env) userUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := env.dao.UpdateUser(userID, req)
+	resp, err := env.dao.UpdateUser(dao.UpdateUserInput{
+		ID:   userID,
+		Name: req.Name,
+	})
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrUserNotFound:
@@ -136,17 +177,23 @@ func (env *Env) userUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	json.NewEncoder(w).Encode(resp)
+
+	json.NewEncoder(w).Encode(userUpdateResponse{
+		ID:   resp.ID,
+		Name: resp.Name,
+	})
 }
 
-func (env *Env) userDeleteHandler(w http.ResponseWriter, r *http.Request) {
+func (env *env) userDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	userID, err := util.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
 		http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusBadRequest)
 		return
 	}
 
-	err = env.dao.DeleteUser(userID)
+	err = env.dao.DeleteUser(dao.DeleteUserInput{
+		ID: userID,
+	})
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrUserNotFound:


### PR DESCRIPTION
So that we can easily modify the `request` and `response` types using `@serverSet` values etc. we have separated these from the actual types that are stored in the datastore.

This also means the DAO is completely separate from request / response - following the Go structure of isolation by responsibility.

All unit tests should still pass since the actual content of requests/responses shouldn't change.