### PR TITLE
[user][test] Make tests consistent between endpoints

### DIFF
--- a/user/user_test.go
+++ b/user/user_test.go
@@ -77,7 +77,7 @@ func TestCreateUserHandlerSucceeds(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	// Make a single user
+	// Create a single user
 	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
@@ -100,7 +100,7 @@ func TestCreateUserHandlerFailsOnEmptyParameter(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	// Make a single user
+	// Create a single user
 	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": ""}`)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
@@ -117,7 +117,7 @@ func TestCreateUserHandlerFailsOnMalformedJSONBody(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	// Make a single user
+	// Create a single user
 	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name"`)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
@@ -134,7 +134,7 @@ func TestCreateUserHandlerFailsOnNoBody(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	// Make a single user
+	// Create a single user
 	res, err := makeRequest(mockEnv, http.MethodPost, "/user", "")
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
@@ -151,7 +151,7 @@ func TestReadUserHandlerSucceeds(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	// Make a single user
+	// Create a single user
 	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
@@ -191,7 +191,7 @@ func TestReadUserHandlerFailsOnEmptyID(t *testing.T) {
 	}
 }
 
-// Test that providing a non existent ID to the read endpoint fails
+// Test that providing a non-existent ID to the read endpoint fails
 func TestReadUserHandlerFailsOnNonExistentID(t *testing.T) {
 	mockEnv := env{
 		&MockDAO{UserList: make([]dao.User, 0)},
@@ -231,7 +231,7 @@ func TestUpdateUserHandlerSucceeds(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	// Make a single user
+	// Create a single user
 	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
@@ -260,7 +260,7 @@ func TestUpdateUserHandlerFailsOnEmptyParameter(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	// Make a single user
+	// Create a single user
 	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
@@ -283,7 +283,7 @@ func TestUpdateUserHandlerFailsOnMalformedJSONBody(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	// Make a single user
+	// Create a single user
 	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
@@ -306,7 +306,7 @@ func TestUpdateUserHandlerFailsOnNoBody(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	// Make a single user
+	// Create a single user
 	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
@@ -340,7 +340,7 @@ func TestUpdateUserHandlerFailsOnEmptyID(t *testing.T) {
 	}
 }
 
-// Test that providing a non existent ID to the update endpoint fails
+// Test that providing a non-existent ID to the update endpoint fails
 func TestUpdateUserHandlerFailsOnNonExistentID(t *testing.T) {
 	mockEnv := env{
 		&MockDAO{UserList: make([]dao.User, 0)},
@@ -380,7 +380,7 @@ func TestDeleteUserHandlerSucceeds(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	// Make a single user
+	// Create a single user
 	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
@@ -420,7 +420,7 @@ func TestDeleteUserHandlerFailsOnEmptyID(t *testing.T) {
 	}
 }
 
-// Test that providing a non existent ID to the delete endpoint fails
+// Test that providing a non-existent ID to the delete endpoint fails
 func TestDeleteUserHandlerFailsOnNonExistentID(t *testing.T) {
 	mockEnv := env{
 		&MockDAO{UserList: make([]dao.User, 0)},

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -73,12 +73,13 @@ func makeRequest(env Env, method string, url string, body string) (*httptest.Res
 	return rec, nil
 }
 
-// Test that a user can be successfully created
-func TestUserCreateHandlerSucceeds(t *testing.T) {
+// Test that a single user can be successfully created
+func TestCreateUserHandlerSucceeds(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
 
+	// Make a single user
 	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
@@ -95,12 +96,13 @@ func TestUserCreateHandlerSucceeds(t *testing.T) {
 	}
 }
 
-// Test that providing an empty value for the `Name` parameter causes a `StatusBadRequest`
-func TestUserCreateHandlerFailsOnEmptyParameter(t *testing.T) {
+// Test that providing an empty parameter to the create endpoint fails
+func TestCreateUserHandlerFailsOnEmptyParameter(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
 
+	// Make a single user
 	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": ""}`)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
@@ -111,12 +113,30 @@ func TestUserCreateHandlerFailsOnEmptyParameter(t *testing.T) {
 	}
 }
 
-// Test that providing no body to the request causes a `StatusBadRequest`
-func TestUserCreateHandlerFailsOnNoBody(t *testing.T) {
+// Test that providing a malformed JSON body to the create endpoint fails
+func TestCreateUserHandlerFailsOnMalformedJSONBody(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
 
+	// Make a single user
+	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name"`)
+	if err != nil {
+		t.Fatalf("Could not make POST request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
+// Test that providing no body to the create endpoint fails
+func TestCreateUserHandlerFailsOnNoBody(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	// Make a single user
 	res, err := makeRequest(mockEnv, http.MethodPost, "/user", "")
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
@@ -127,19 +147,19 @@ func TestUserCreateHandlerFailsOnNoBody(t *testing.T) {
 	}
 }
 
-// Test that a user can be successfully created and then read back
-func TestUserReadHandlerSucceeds(t *testing.T) {
+// Test that a single user can be successfully created and then read back
+func TestReadUserHandlerSucceeds(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
 
-	// Make a user
+	// Make a single user
 	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
 	}
 
-	// Access that same user
+	// Read that same user
 	res, err := makeRequest(mockEnv, http.MethodGet, "/user/0", "")
 	if err != nil {
 		t.Fatalf("Could not make GET request: %s", err.Error())
@@ -157,7 +177,7 @@ func TestUserReadHandlerSucceeds(t *testing.T) {
 }
 
 // Test that providing no ID to the read endpoint fails
-func TestUserReadHandlerFailsOnEmptyID(t *testing.T) {
+func TestReadUserHandlerFailsOnEmptyID(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
@@ -173,8 +193,8 @@ func TestUserReadHandlerFailsOnEmptyID(t *testing.T) {
 	}
 }
 
-// Test that providing an invalid ID to the read endpoint fails
-func TestUserReadHandlerFailsOnNonExistentID(t *testing.T) {
+// Test that providing a non existent ID to the read endpoint fails
+func TestReadUserHandlerFailsOnNonExistentID(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
@@ -190,8 +210,8 @@ func TestUserReadHandlerFailsOnNonExistentID(t *testing.T) {
 	}
 }
 
-// Test that providing a string as ID to the read endpoint fails
-func TestUserReadHandlerFailsOnStringID(t *testing.T) {
+// Test that providing a string ID to the read endpoint fails
+func TestReadUserHandlerFailsOnStringID(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
@@ -207,13 +227,13 @@ func TestUserReadHandlerFailsOnStringID(t *testing.T) {
 	}
 }
 
-// Test that a user can be successfully created and then updated
-func TestUserUpdateHandlerSucceeds(t *testing.T) {
+// Test that a single user can be successfully created and then updated
+func TestUpdateUserHandlerSucceeds(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
 
-	// Make a user
+	// Make a single user
 	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
@@ -236,13 +256,13 @@ func TestUserUpdateHandlerSucceeds(t *testing.T) {
 	}
 }
 
-// Test that providing an empty name to the update endpoint fails
-func TestUserUpdateHandlerFailsOnEmptyName(t *testing.T) {
+// Test that providing an empty parameter to the update endpoint fails
+func TestUpdateUserHandlerFailsOnEmptyParameter(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
 
-	// Make a user
+	// Make a single user
 	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
@@ -259,13 +279,13 @@ func TestUserUpdateHandlerFailsOnEmptyName(t *testing.T) {
 	}
 }
 
-// Test that providing malformed JSON to the update endpoint fails
-func TestUserUpdateHandlerFailsOnInvalidRequestBody(t *testing.T) {
+// Test that providing a malformed JSON body to the update endpoint fails
+func TestUpdateUserHandlerFailsOnMalformedJSONBody(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
 
-	// Make a user
+	// Make a single user
 	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
@@ -282,8 +302,31 @@ func TestUserUpdateHandlerFailsOnInvalidRequestBody(t *testing.T) {
 	}
 }
 
+// Test that providing no body to the update endpoint fails
+func TestUpdateUserHandlerFailsOnNoBody(t *testing.T) {
+	var mockEnv = Env{
+		&MockDAO{Users: make([]MockUser, 0)},
+	}
+
+	// Make a single user
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
+	if err != nil {
+		t.Fatalf("Could not make POST request: %s", err.Error())
+	}
+
+	// Update that same user
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", "")
+	if err != nil {
+		t.Fatalf("Could not make PUT request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code %v", res.Code)
+	}
+}
+
 // Test that providing no ID to the update endpoint fails
-func TestUserUpdateHandlerFailsOnEmptyID(t *testing.T) {
+func TestUpdateUserHandlerFailsOnEmptyID(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
@@ -293,14 +336,14 @@ func TestUserUpdateHandlerFailsOnEmptyID(t *testing.T) {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
 
-	// 404 Not Found, since no route is defined for PUT at /user
+	// Not Found, since no route is defined for PUT at /user
 	if res.Code != http.StatusNotFound {
 		t.Errorf("Wrong status code %v", res.Code)
 	}
 }
 
-// Test that providing an invalid ID to the update endpoint fails
-func TestUserUpdateHandlerFailsOnNonExistentID(t *testing.T) {
+// Test that providing a non existent ID to the update endpoint fails
+func TestUpdateUserHandlerFailsOnNonExistentID(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
@@ -310,14 +353,14 @@ func TestUserUpdateHandlerFailsOnNonExistentID(t *testing.T) {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
 
-	// 404 Not Found, since no user exists with that given ID
+	// Not Found, since no user exists with that given ID
 	if res.Code != http.StatusNotFound {
 		t.Errorf("Wrong status code %v", res.Code)
 	}
 }
 
-// Test that providing a string as ID to the update endpoint fails
-func TestUserUpdateHandlerFailsOnStringID(t *testing.T) {
+// Test that providing a string ID to the update endpoint fails
+func TestUpdateUserHandlerFailsOnStringID(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
@@ -333,19 +376,19 @@ func TestUserUpdateHandlerFailsOnStringID(t *testing.T) {
 	}
 }
 
-// Test that a user can be successfully created and then deleted
-func TestUserDeleteHandlerSucceeds(t *testing.T) {
+// Test that a single user can be successfully created and then deleted
+func TestDeleteUserHandlerSucceeds(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
 
-	// Make a user
+	// Make a single user
 	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
 	}
 
-	// Update that same user
+	// Delete that same user
 	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/0", "")
 	if err != nil {
 		t.Fatalf("Could not make DELETE request: %s", err.Error())
@@ -363,7 +406,7 @@ func TestUserDeleteHandlerSucceeds(t *testing.T) {
 }
 
 // Test that providing no ID to the delete endpoint fails
-func TestUserDeleteHandlerFailsOnEmptyID(t *testing.T) {
+func TestDeleteUserHandlerFailsOnEmptyID(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
@@ -373,14 +416,14 @@ func TestUserDeleteHandlerFailsOnEmptyID(t *testing.T) {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
 
-	// 404 Not Found, since no route is defined for DELETE at /user
+	// Not Found, since no route is defined for DELETE at /user
 	if res.Code != http.StatusNotFound {
 		t.Errorf("Wrong status code %v", res.Code)
 	}
 }
 
-// Test that providing an invalid ID to the delete endpoint fails
-func TestUserDeleteHandlerFailsOnNonExistentID(t *testing.T) {
+// Test that providing a non existent ID to the delete endpoint fails
+func TestDeleteUserHandlerFailsOnNonExistentID(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}
@@ -390,14 +433,14 @@ func TestUserDeleteHandlerFailsOnNonExistentID(t *testing.T) {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
 
-	// 404 Not Found, since no user exists with that given ID
+	// Not Found, since no user exists with that given ID
 	if res.Code != http.StatusNotFound {
 		t.Errorf("Wrong status code %v", res.Code)
 	}
 }
 
-// Test that providing a string as ID to the delete endpoint fails
-func TestUserDeleteHandlerFailsOnStringID(t *testing.T) {
+// Test that providing a string ID to the delete endpoint fails
+func TestDeleteUserHandlerFailsOnStringID(t *testing.T) {
 	var mockEnv = Env{
 		&MockDAO{Users: make([]MockUser, 0)},
 	}


### PR DESCRIPTION
- Move tests to the structure `<verb><service><type>`
- Make comments consistent between each test
- Make ordering of tests consistent between handlers
- Avoid names where we require the use of `a` or `an` depending on the name