### PR TITLE
[user][auth] Store AuthID alongside user and validate in requests

### DIFF
--- a/user-db/init.sql
+++ b/user-db/init.sql
@@ -1,4 +1,5 @@
 CREATE TABLE User_Temple (
     id SERIAL PRIMARY KEY,
+    auth_id INT NOT NULL,
     name TEXT
 );

--- a/user/dao/dao.go
+++ b/user/dao/dao.go
@@ -24,13 +24,15 @@ type DAO struct {
 
 // User encapsulates the object stored in the datastore
 type User struct {
-	ID   int64
-	Name string
+	ID     int64
+	AuthID int64
+	Name   string
 }
 
 // CreateUserInput encapsulates the information required to create a single user
 type CreateUserInput struct {
-	Name string
+	AuthID int64
+	Name   string
 }
 
 // ReadUserInput encapsulates the information required to read a single user
@@ -76,10 +78,10 @@ func Init(config *util.Config) (*DAO, error) {
 
 // CreateUser creates a new user in the database, returning the newly created user
 func (dao *DAO) CreateUser(input CreateUserInput) (*User, error) {
-	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO User_Temple (name) VALUES ($1) RETURNING *", input.Name)
+	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO User_Temple (auth_id, name) VALUES ($1, $2) RETURNING *", input.AuthID, input.Name)
 
 	var user User
-	err := row.Scan(&user.ID, &user.Name)
+	err := row.Scan(&user.ID, &user.AuthID, &user.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +112,7 @@ func (dao *DAO) UpdateUser(input UpdateUserInput) (*User, error) {
 	row := executeQueryWithRowResponse(dao.DB, "UPDATE User_Temple set Name = $1 WHERE Id = $2 RETURNING *", input.Name, input.ID)
 
 	var user User
-	err := row.Scan(&user.ID, &user.Name)
+	err := row.Scan(&user.ID, &user.AuthID, &user.Name)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/user/go.mod
+++ b/user/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/mux v1.7.4
 	github.com/lib/pq v1.3.0
 )

--- a/user/go.sum
+++ b/user/go.sum
@@ -1,5 +1,7 @@
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -9,19 +9,25 @@ import (
 	"github.com/TempleEight/spec-golang/user/dao"
 )
 
+// Define 2 JWTs with ID 0 and 1
+const User0JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1ODMyNTc5NzcsImlkIjowLCJpc3MiOiJmRlM4S21WWXVLQUN5RjN3ZHBQS0hTUXFtWlZWd2pEcSJ9.KzUa-OpHEjFQlsSy7YZI1Kppu4eIU5nyivLvivWcpRc"
+const User1JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1ODMyNTc5NzcsImlkIjoxLCJpc3MiOiJmRlM4S21WWXVLQUN5RjN3ZHBQS0hTUXFtWlZWd2pEcSJ9.kXaTT0Yl3-zeWreKOl5Zd6dG1gJG49JSS0zfdBRG_oU"
+
 type MockDAO struct {
 	UserList []dao.User
 }
 
 func (md *MockDAO) CreateUser(input dao.CreateUserInput) (*dao.User, error) {
 	mockUser := dao.User{
-		ID:   int64(len(md.UserList)),
-		Name: input.Name,
+		ID:     int64(len(md.UserList)),
+		AuthID: input.AuthID,
+		Name:   input.Name,
 	}
 	md.UserList = append(md.UserList, mockUser)
 	return &dao.User{
-		ID:   mockUser.ID,
-		Name: mockUser.Name,
+		ID:     mockUser.ID,
+		AuthID: mockUser.AuthID,
+		Name:   mockUser.Name,
 	}, nil
 }
 
@@ -29,8 +35,9 @@ func (md *MockDAO) ReadUser(input dao.ReadUserInput) (*dao.User, error) {
 	for _, user := range md.UserList {
 		if user.ID == input.ID {
 			return &dao.User{
-				ID:   user.ID,
-				Name: user.Name,
+				ID:     user.ID,
+				AuthID: user.AuthID,
+				Name:   user.Name,
 			}, nil
 		}
 	}
@@ -42,8 +49,9 @@ func (md *MockDAO) UpdateUser(input dao.UpdateUserInput) (*dao.User, error) {
 		if user.ID == input.ID {
 			md.UserList[i].Name = user.Name
 			return &dao.User{
-				ID:   input.ID,
-				Name: input.Name,
+				ID:     user.ID,
+				AuthID: user.AuthID,
+				Name:   input.Name,
 			}, nil
 		}
 	}
@@ -60,9 +68,10 @@ func (md *MockDAO) DeleteUser(input dao.DeleteUserInput) error {
 	return dao.ErrUserNotFound(input.ID)
 }
 
-func makeRequest(env env, method string, url string, body string) (*httptest.ResponseRecorder, error) {
+func makeRequest(env env, method string, url string, body string, authToken string) (*httptest.ResponseRecorder, error) {
 	rec := httptest.NewRecorder()
 	req, err := http.NewRequest(method, url, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+authToken)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +87,7 @@ func TestCreateUserHandlerSucceeds(t *testing.T) {
 	}
 
 	// Create a single user
-	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
+	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`, User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
@@ -101,7 +110,7 @@ func TestCreateUserHandlerFailsOnEmptyParameter(t *testing.T) {
 	}
 
 	// Create a single user
-	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": ""}`)
+	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": ""}`, User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
@@ -118,7 +127,7 @@ func TestCreateUserHandlerFailsOnMalformedJSONBody(t *testing.T) {
 	}
 
 	// Create a single user
-	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name"`)
+	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name"`, User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
 	}
@@ -135,12 +144,29 @@ func TestCreateUserHandlerFailsOnNoBody(t *testing.T) {
 	}
 
 	// Create a single user
-	res, err := makeRequest(mockEnv, http.MethodPost, "/user", "")
+	res, err := makeRequest(mockEnv, http.MethodPost, "/user", "", User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
 
 	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing an empty JWT to the create endpoint fails
+func TestCreateUserHandlerFailsOnEmptyJWT(t *testing.T) {
+	mockEnv := env{
+		&MockDAO{UserList: make([]dao.User, 0)},
+	}
+
+	// Create a single user
+	res, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`, "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusUnauthorized {
 		t.Errorf("Wrong status code: %v", res.Code)
 	}
 }
@@ -152,13 +178,13 @@ func TestReadUserHandlerSucceeds(t *testing.T) {
 	}
 
 	// Create a single user
-	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`, User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
 	}
 
 	// Read that same user
-	res, err := makeRequest(mockEnv, http.MethodGet, "/user/0", "")
+	res, err := makeRequest(mockEnv, http.MethodGet, "/user/0", "", User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make GET request: %s", err.Error())
 	}
@@ -180,12 +206,12 @@ func TestReadUserHandlerFailsOnEmptyID(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodGet, "/user/", "")
+	res, err := makeRequest(mockEnv, http.MethodGet, "/user/", "", User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
 
-	// 404 Not Found, since no route is defined for GET at /user
+	// Not Found, since no route is defined for GET at /user
 	if res.Code != http.StatusNotFound {
 		t.Errorf("Wrong status code: %v", res.Code)
 	}
@@ -197,12 +223,12 @@ func TestReadUserHandlerFailsOnNonExistentID(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodGet, "/user/123456", "")
+	res, err := makeRequest(mockEnv, http.MethodGet, "/user/123456", "", User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
 
-	// 404 Not Found, since no user exists with that given ID
+	// Not Found, since no user exists with that given ID
 	if res.Code != http.StatusNotFound {
 		t.Errorf("Wrong status code: %v", res.Code)
 	}
@@ -214,13 +240,29 @@ func TestReadUserHandlerFailsOnStringID(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodGet, "/user/abcdef", "")
+	res, err := makeRequest(mockEnv, http.MethodGet, "/user/abcdef", "", User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
 
 	// Bad request, since we require an integer
 	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing an empty JWT to the read endpoint fails
+func TestReadUserHandlerFailsOnEmptyJWT(t *testing.T) {
+	mockEnv := env{
+		&MockDAO{UserList: make([]dao.User, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodGet, "/user/0", `{"Name": "Jay"}`, "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusUnauthorized {
 		t.Errorf("Wrong status code: %v", res.Code)
 	}
 }
@@ -232,13 +274,13 @@ func TestUpdateUserHandlerSucceeds(t *testing.T) {
 	}
 
 	// Create a single user
-	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`, User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
 	}
 
 	// Update that same user
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name": "Lewis"}`)
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name": "Lewis"}`, User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make PUT request: %s", err.Error())
 	}
@@ -261,13 +303,13 @@ func TestUpdateUserHandlerFailsOnEmptyParameter(t *testing.T) {
 	}
 
 	// Create a single user
-	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`, User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
 	}
 
 	// Update that same user
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name": ""}`)
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name": ""}`, User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make PUT request: %s", err.Error())
 	}
@@ -284,13 +326,13 @@ func TestUpdateUserHandlerFailsOnMalformedJSONBody(t *testing.T) {
 	}
 
 	// Create a single user
-	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`, User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
 	}
 
 	// Update that same user
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name"}`)
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name"}`, User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make PUT request: %s", err.Error())
 	}
@@ -307,13 +349,13 @@ func TestUpdateUserHandlerFailsOnNoBody(t *testing.T) {
 	}
 
 	// Create a single user
-	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`, User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
 	}
 
 	// Update that same user
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", "")
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", "", User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make PUT request: %s", err.Error())
 	}
@@ -329,7 +371,7 @@ func TestUpdateUserHandlerFailsOnEmptyID(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/", "")
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/", "", User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
@@ -346,13 +388,13 @@ func TestUpdateUserHandlerFailsOnNonExistentID(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/123456", `{"Name":"Will"}`)
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/123456", `{"Name":"Will"}`, User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
 
-	// Not Found, since no user exists with that given ID
-	if res.Code != http.StatusNotFound {
+	// Unauthorized, since no user can update information about another user
+	if res.Code != http.StatusUnauthorized {
 		t.Errorf("Wrong status code: %v", res.Code)
 	}
 }
@@ -363,13 +405,52 @@ func TestUpdateUserHandlerFailsOnStringID(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/abcdef", "")
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/abcdef", "", User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
 
 	// Bad request, since we require an integer
 	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing an empty JWT to the update endpoint fails
+func TestUpdateUserHandlerFailsOnEmptyJWT(t *testing.T) {
+	mockEnv := env{
+		&MockDAO{UserList: make([]dao.User, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name": "Jay"}`, "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusUnauthorized {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing a different JWT to the update endpoint fails
+func TestUpdateUserHandlerFailsOnDifferentJWT(t *testing.T) {
+	mockEnv := env{
+		&MockDAO{UserList: make([]dao.User, 0)},
+	}
+
+	// Create a single user with User0JWT
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`, User0JWT)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// Update a single user with User1JWT
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name": "Lewis"}`, User1JWT)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusUnauthorized {
 		t.Errorf("Wrong status code: %v", res.Code)
 	}
 }
@@ -381,13 +462,13 @@ func TestDeleteUserHandlerSucceeds(t *testing.T) {
 	}
 
 	// Create a single user
-	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`)
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`, User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make POST request: %s", err.Error())
 	}
 
 	// Delete that same user
-	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/0", "")
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/0", "", User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make DELETE request: %s", err.Error())
 	}
@@ -409,7 +490,7 @@ func TestDeleteUserHandlerFailsOnEmptyID(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/", "")
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/", "", User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
@@ -426,13 +507,13 @@ func TestDeleteUserHandlerFailsOnNonExistentID(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/123456", "")
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/123456", "", User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
 
-	// Not Found, since no user exists with that given ID
-	if res.Code != http.StatusNotFound {
+	// Unauthorized, since no user can delete information about another user
+	if res.Code != http.StatusUnauthorized {
 		t.Errorf("Wrong status code: %v", res.Code)
 	}
 }
@@ -443,13 +524,52 @@ func TestDeleteUserHandlerFailsOnStringID(t *testing.T) {
 		&MockDAO{UserList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/abcdef", "")
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/abcdef", "", User0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
 
 	// Bad request, since we require an integer
 	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing an empty JWT to the delete endpoint fails
+func TestDeleteUserHandlerFailsOnEmptyJWT(t *testing.T) {
+	mockEnv := env{
+		&MockDAO{UserList: make([]dao.User, 0)},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/0", "", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusUnauthorized {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing a different JWT to the delete endpoint fails
+func TestDeleteUserHandlerFailsOnDifferentJWT(t *testing.T) {
+	mockEnv := env{
+		&MockDAO{UserList: make([]dao.User, 0)},
+	}
+
+	// Create a single user with User0JWT
+	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`, User0JWT)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// Delete a single user with User1JWT
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/0", "", User1JWT)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusUnauthorized {
 		t.Errorf("Wrong status code: %v", res.Code)
 	}
 }


### PR DESCRIPTION
We now validate that the same auth that created a "User" can be the only one that can modify or delete it.

We do not explicitly check the auth when reading a user, since we assume that the "User" is a publicly accessible resource to any user with a JWT (@xsanda we should think of a way to express this in Templefile).

I've added unit tests to reflect these changes (yay!)