### PR TITLE
[auth] Add JSON content type header to each response

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -51,6 +51,7 @@ func (env *env) router() *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/auth", env.createAuthHandler).Methods(http.MethodPost)
 	r.HandleFunc("/auth", env.readAuthHandler).Methods(http.MethodGet)
+	r.Use(jsonMiddleware)
 	return r
 }
 
@@ -80,6 +81,14 @@ func main() {
 	env := env{d, c, jwtCredential}
 
 	log.Fatal(http.ListenAndServe(":82", env.router()))
+}
+
+func jsonMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// All responses are JSON, set header accordingly
+		w.Header().Set("Content-Type", "application/json")
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (env *env) createAuthHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Closes #52 

Test plan:

```
curl -v -X POST localhost:8000/api/auth -d '{"email":"jay@test.com", "password":"abcdefgh"}'
...
< Content-Type: application/json
< Content-Length: 188
< Connection: keep-alive
< Date: Mon, 09 Mar 2020 15:38:21 GMT
< X-Kong-Upstream-Latency: 126
< X-Kong-Proxy-Latency: 48
< Via: kong/2.0.1
< 
{"AccessToken":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1ODM4NTQ3MDEsImlkIjoxLCJpc3MiOiJjUkVSQ25hWmNjeWxiZkNCN0pkYnRLc2RVa2R1VzFVNyJ9.gsaR3n6x8rbFQI3eTg0AdcJVWIsh2HgHAkSm-TG7sE4"}
* Connection #0 to host localhost left intact
* Closing connection 0
```