### PR TITLE
[go-gen] Add unit tests to Match service

### DIFF
--- a/match/match_test.go
+++ b/match/match_test.go
@@ -107,8 +107,8 @@ func makeRequest(env env, method string, url string, body string) (*httptest.Res
 	return rec, nil
 }
 
-// Test that a match can be created successfully, assuming each user exists
-func TestMatchCreateHandlerSucceeds(t *testing.T) {
+// Test that a single match can be created successfully
+func TestCreateMatchHandlerSucceeds(t *testing.T) {
 	mockEnv := env{
 		&mockDAO{matchList: make([]dao.Match, 0)},
 		&mockComm{userIDs: []int64{0, 1}},
@@ -120,7 +120,7 @@ func TestMatchCreateHandlerSucceeds(t *testing.T) {
 	}
 
 	if res.Code != http.StatusOK {
-		t.Errorf("Wrong status code %v", res.Code)
+		t.Errorf("Wrong status code: %v", res.Code)
 	}
 
 	received := res.Body.String()
@@ -131,7 +131,7 @@ func TestMatchCreateHandlerSucceeds(t *testing.T) {
 }
 
 // Test that a match is not created if UserOne doesn't exist
-func TestMatchCreateHandlerFailsOnInvalidUserOne(t *testing.T) {
+func TestCreateMatchHandlerFailsOnInvalidUserOne(t *testing.T) {
 	mockEnv := env{
 		&mockDAO{matchList: make([]dao.Match, 0)},
 		&mockComm{userIDs: []int64{0, 1}},
@@ -143,12 +143,12 @@ func TestMatchCreateHandlerFailsOnInvalidUserOne(t *testing.T) {
 	}
 
 	if res.Code != http.StatusBadRequest {
-		t.Errorf("Wrong status code %v", res.Code)
+		t.Errorf("Wrong status code: %v", res.Code)
 	}
 }
 
 // Test that a match is not created if UserTwo doesn't exist
-func TestMatchCreateHandlerFailsOnInvalidUserTwo(t *testing.T) {
+func TestCreateMatchHandlerFailsOnInvalidUserTwo(t *testing.T) {
 	mockEnv := env{
 		&mockDAO{matchList: make([]dao.Match, 0)},
 		&mockComm{userIDs: []int64{0, 1}},
@@ -160,12 +160,12 @@ func TestMatchCreateHandlerFailsOnInvalidUserTwo(t *testing.T) {
 	}
 
 	if res.Code != http.StatusBadRequest {
-		t.Errorf("Wrong status code %v", res.Code)
+		t.Errorf("Wrong status code: %v", res.Code)
 	}
 }
 
 // Test that a match is not created if every reference doesn't exist
-func TestMatchCreateHandlerFailsOnAllInvalidReferences(t *testing.T) {
+func TestCreateMatchHandlerFailsOnAllInvalidReferences(t *testing.T) {
 	mockEnv := env{
 		&mockDAO{matchList: make([]dao.Match, 0)},
 		&mockComm{userIDs: []int64{0, 1}},
@@ -177,12 +177,12 @@ func TestMatchCreateHandlerFailsOnAllInvalidReferences(t *testing.T) {
 	}
 
 	if res.Code != http.StatusBadRequest {
-		t.Errorf("Wrong status code %v", res.Code)
+		t.Errorf("Wrong status code: %v", res.Code)
 	}
 }
 
 // Test that a match is not created if the request body is not complete
-func TestMatchCreateHandlerFailsOnOnlyProvidingOneUser(t *testing.T) {
+func TestCreateMatchHandlerFailsOnOnlyProvidingOneUser(t *testing.T) {
 	mockEnv := env{
 		&mockDAO{matchList: make([]dao.Match, 0)},
 		&mockComm{userIDs: []int64{0, 1}},
@@ -194,12 +194,12 @@ func TestMatchCreateHandlerFailsOnOnlyProvidingOneUser(t *testing.T) {
 	}
 
 	if res.Code != http.StatusBadRequest {
-		t.Errorf("Wrong status code %v", res.Code)
+		t.Errorf("Wrong status code: %v", res.Code)
 	}
 }
 
 // Test that creating a match fails if the request body is malformed
-func TestMatchCreateHandlerFailsOnMalformedJSONBody(t *testing.T) {
+func TestCreateMatchHandlerFailsOnMalformedJSONBody(t *testing.T) {
 	mockEnv := env{
 		&mockDAO{matchList: make([]dao.Match, 0)},
 		&mockComm{userIDs: []int64{0, 1}},
@@ -211,6 +211,6 @@ func TestMatchCreateHandlerFailsOnMalformedJSONBody(t *testing.T) {
 	}
 
 	if res.Code != http.StatusBadRequest {
-		t.Errorf("Wrong status code %v", res.Code)
+		t.Errorf("Wrong status code: %v", res.Code)
 	}
 }

--- a/match/match_test.go
+++ b/match/match_test.go
@@ -107,6 +107,42 @@ func makeRequest(env env, method string, url string, body string) (*httptest.Res
 	return rec, nil
 }
 
+// Test that a match list can be read successfully
+func TestListMatchHandlerSucceeds(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1, 2, 3}},
+	}
+
+	// Create a first match
+	_, err := makeRequest(mockEnv, http.MethodPost, "/match", `{"UserOne": 0, "UserTwo": 1}`)
+	if err != nil {
+		t.Fatalf("Could not make first POST request: %s", err.Error())
+	}
+
+	// Create a second match
+	_, err = makeRequest(mockEnv, http.MethodPost, "/match", `{"UserOne": 2, "UserTwo": 3}`)
+	if err != nil {
+		t.Fatalf("Could not make second POST request: %s", err.Error())
+	}
+
+	// Read the match list
+	res, err := makeRequest(mockEnv, http.MethodGet, "/match/all", "")
+	if err != nil {
+		t.Fatalf("Could not make GET request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusOK {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+
+	received := res.Body.String()
+	expected := `{"MatchList":[{"ID":0,"UserOne":0,"UserTwo":1,"MatchedOn":"2020-01-01T12:00:00.000000Z"},{"ID":1,"UserOne":2,"UserTwo":3,"MatchedOn":"2020-01-01T12:00:00.000000Z"}]}`
+	if expected != strings.TrimSuffix(received, "\n") {
+		t.Errorf("Handler returned incorrect body: received %+v, expected %+v", received, expected)
+	}
+}
+
 // Test that a single match can be created successfully
 func TestCreateMatchHandlerSucceeds(t *testing.T) {
 	mockEnv := env{
@@ -233,7 +269,7 @@ func TestCreateMatchHandlerFailsOnAllInvalidReferences(t *testing.T) {
 	}
 }
 
-// Test that a single match can be successfully created and read back
+// Test that a single match can be read successfully
 func TestReadMatchHandlerSucceeds(t *testing.T) {
 	mockEnv := env{
 		&mockDAO{matchList: make([]dao.Match, 0)},
@@ -246,7 +282,7 @@ func TestReadMatchHandlerSucceeds(t *testing.T) {
 		t.Fatalf("Could not make POST request: %s", err.Error())
 	}
 
-	// Read that same match
+	// Read the match
 	res, err := makeRequest(mockEnv, http.MethodGet, "/match/0", "")
 	if err != nil {
 		t.Fatalf("Could not make GET request: %s", err.Error())
@@ -307,6 +343,276 @@ func TestReadUserHandlerFailsOnStringID(t *testing.T) {
 	}
 
 	res, err := makeRequest(mockEnv, http.MethodGet, "/match/abcdef", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// Bad Request, since we require an integer
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that a single match can be updated successfully
+func TestUpdateUserHandlerSucceeds(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	// Create a single match
+	_, err := makeRequest(mockEnv, http.MethodPost, "/match", `{"UserOne": 0, "UserTwo": 1}`)
+	if err != nil {
+		t.Fatalf("Could not make POST request: %s", err.Error())
+	}
+
+	// Update the match
+	res, err := makeRequest(mockEnv, http.MethodPut, "/match/0", `{"UserOne": 1, "UserTwo": 0}`)
+	if err != nil {
+		t.Fatalf("Could not make PUT request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusOK {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+
+	received := res.Body.String()
+	expected := `{"ID":0,"UserOne":1,"UserTwo":0,"MatchedOn":"2020-12-31T12:00:00.000000Z"}`
+	if expected != strings.TrimSuffix(received, "\n") {
+		t.Errorf("Handler returned incorrect body: received %+v, expected %+v", received, expected)
+	}
+}
+
+// Test that providing an incomplete to the update endpoint fails
+func TestUpdateMatchHandlerFailsOnIncompleteBody(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPost, "/match", `{"UserOne": 0}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing a malformed JSON body to the update endpoint fails
+func TestUpdateMatchHandlerFailsOnMalformedJSONBody(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPut, "/match/0", `{"UserOne"`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing no body to the update endpoint fails
+func TestUpdateMatchHandlerFailsOnNoBody(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPut, "/match/0", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing no ID to the update endpoint fails
+func TestUpdateMatchHandlerFailsOnEmptyID(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPut, "/match/", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// Not Found, since no route is defined for PUT at /match
+	if res.Code != http.StatusNotFound {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing a non-existent ID to the update endpoint fails
+func TestUpdateMatchHandlerFailsOnNonExistentID(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPut, "/match/123456", `{"UserOne": 0, "UserTwo": 1}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// Not Found, since no match exists with that given ID
+	if res.Code != http.StatusNotFound {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing a string ID to the update endpoint fails
+func TestUpdateMatchHandlerFailsOnStringID(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodGet, "/match/abcdef", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// Bad Request, since we require an integer
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing an invalid UserOne reference to the update endpoint fails
+func TestUpdateMatchHandlerFailsOnInvalidUserOne(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPut, "/match/0", `{"UserOne": 123456, "UserTwo": 0}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing an invalid UserTwo reference to the update endpoint fails
+func TestUpdateMatchHandlerFailsOnInvalidUserTwo(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPut, "/match/0", `{"UserOne": 0, "UserTwo": 123456}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing all invalid references to the update endpoint fails
+func TestUpdateMatchHandlerFailsOnAllInvalidReferences(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodPut, "/match/0", `{"UserOne": 123456, "UserTwo": 234567}`)
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusBadRequest {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that a single match can be deleted successfully
+func TestDeleteMatchHandlerSucceeds(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	// Create a single match
+	_, err := makeRequest(mockEnv, http.MethodPost, "/match", `{"UserOne": 0, "UserTwo": 1}`)
+	if err != nil {
+		t.Fatalf("Could not make POST request: %s", err.Error())
+	}
+
+	// Delete the match
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/match/0", "")
+	if err != nil {
+		t.Fatalf("Could not make DELETE request: %s", err.Error())
+	}
+
+	if res.Code != http.StatusOK {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+
+	received := res.Body.String()
+	expected := `{}`
+	if expected != strings.TrimSuffix(received, "\n") {
+		t.Errorf("Handler returned incorrect body: received %+v expected %+v", received, expected)
+	}
+}
+
+// Test that providing no ID to the delete endpoint fails
+func TestDeleteMatchHandlerFailsOnEmptyID(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/match/", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// Not Found, since no route is defined for DELETE at /match
+	if res.Code != http.StatusNotFound {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing a non-existent ID to the delete endpoint fails
+func TestDeleteMatchHandlerFailsOnNonExistentID(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/match/123456", "")
+	if err != nil {
+		t.Fatalf("Could not make request: %s", err.Error())
+	}
+
+	// Not Found, since no match exists with that given ID
+	if res.Code != http.StatusNotFound {
+		t.Errorf("Wrong status code: %v", res.Code)
+	}
+}
+
+// Test that providing a string ID to the delete endpoint fails
+func TestDeleteMatchHandlerFailsOnStringID(t *testing.T) {
+	mockEnv := env{
+		&mockDAO{matchList: make([]dao.Match, 0)},
+		&mockComm{userIDs: []int64{0, 1}},
+	}
+
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/match/abcdef", "")
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -133,7 +133,7 @@ func TestCreateUserHandlerFailsOnMalformedJSONBody(t *testing.T) {
 	}
 
 	if res.Code != http.StatusBadRequest {
-		t.Errorf("Wrong status code %v", res.Code)
+		t.Errorf("Wrong status code: %v", res.Code)
 	}
 }
 
@@ -361,7 +361,7 @@ func TestUpdateUserHandlerFailsOnNoBody(t *testing.T) {
 	}
 
 	if res.Code != http.StatusBadRequest {
-		t.Errorf("Wrong status code %v", res.Code)
+		t.Errorf("Wrong status code: %v", res.Code)
 	}
 }
 

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -93,7 +93,7 @@ func TestCreateUserHandlerSucceeds(t *testing.T) {
 	}
 
 	if res.Code != http.StatusOK {
-		t.Errorf("Wrong status code %v", res.Code)
+		t.Errorf("Wrong status code: %v", res.Code)
 	}
 
 	received := res.Body.String()


### PR DESCRIPTION
* Adds unit tests for all handlers, i.e. List and CRUD
* Improves a few minor consistency issues

Order of tests followed here:
* Succeeds
* Empty Parameter in body, only for fields with validation
* Incomplete body, only for bodies with more than one field
* Malformed body
* No body
* Empty ID
* Non existent ID
* String ID
* Interservice-communication validity
    * First reference
    * Second reference
    * …
    * All references

There are still a few consistency issues in the tests, but we're not sure if we'll get round to generating them so it's not worth the time making them perfect now. For now the focus is making the tests useful to us while writing this sample service. Those issues can be fixed/found if/when we generate.

Thankfully the consistency now is pretty good, but for future reference:
* got/want -> received/expected
* Using POST requests to setup tests -> directly appending to mockEnv, more unit test like and cleaner
* Fix comments in user/auth tests on these multi-call tests, e.g. `Read that same user` when the call is actually supplying an empty ID
* Make all tests comments consistent (pretty close now anyway)
