### PR TITLE
[auth][user] Remove auth ID

### DIFF
--- a/user-db/init.sql
+++ b/user-db/init.sql
@@ -1,5 +1,4 @@
 CREATE TABLE user_temple (
     id SERIAL PRIMARY KEY,
-    auth_id INT NOT NULL,
     name TEXT
 );

--- a/user/dao/dao.go
+++ b/user/dao/dao.go
@@ -25,13 +25,11 @@ type DAO struct {
 // User encapsulates the object stored in the datastore
 type User struct {
 	ID     int64
-	AuthID int64
 	Name   string
 }
 
 // CreateUserInput encapsulates the information required to create a single user in the datastore
 type CreateUserInput struct {
-	AuthID int64
 	Name   string
 }
 
@@ -78,10 +76,10 @@ func executeQueryWithRowResponse(db *sql.DB, query string, args ...interface{}) 
 
 // CreateUser creates a new user in the datastore, returning the newly created user
 func (dao *DAO) CreateUser(input CreateUserInput) (*User, error) {
-	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO user_temple (auth_id, name) VALUES ($1, $2) RETURNING *", input.AuthID, input.Name)
+	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO user_temple (name) VALUES ($1) RETURNING *", input.Name)
 
 	var user User
-	err := row.Scan(&user.ID, &user.AuthID, &user.Name)
+	err := row.Scan(&user.ID, &user.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +92,7 @@ func (dao *DAO) ReadUser(input ReadUserInput) (*User, error) {
 	row := executeQueryWithRowResponse(dao.DB, "SELECT * FROM user_temple WHERE id = $1", input.ID)
 
 	var user User
-	err := row.Scan(&user.ID, &user.AuthID, &user.Name)
+	err := row.Scan(&user.ID, &user.Name)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
@@ -112,7 +110,7 @@ func (dao *DAO) UpdateUser(input UpdateUserInput) (*User, error) {
 	row := executeQueryWithRowResponse(dao.DB, "UPDATE user_temple set name = $1 WHERE id = $2 RETURNING *", input.Name, input.ID)
 
 	var user User
-	err := row.Scan(&user.ID, &user.AuthID, &user.Name)
+	err := row.Scan(&user.ID, &user.Name)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/user/user.go
+++ b/user/user.go
@@ -46,11 +46,6 @@ type updateUserResponse struct {
 	Name string
 }
 
-// readUserAuthResponse contains a single user to be returned to the client, with auth ID
-type readUserAuthResponse struct {
-	AuthID int64
-}
-
 // router generates a router for this service
 func (env *env) router() *mux.Router {
 	r := mux.NewRouter()
@@ -58,7 +53,6 @@ func (env *env) router() *mux.Router {
 	r.HandleFunc("/user/{id}", env.readUserHandler).Methods(http.MethodGet)
 	r.HandleFunc("/user/{id}", env.updateUserHandler).Methods(http.MethodPut)
 	r.HandleFunc("/user/{id}", env.deleteUserHandler).Methods(http.MethodDelete)
-	r.HandleFunc("/user/{id}/auth", env.readUserAuthHandler).Methods(http.MethodGet)
 	r.Use(jsonMiddleware)
 	return r
 }
@@ -93,7 +87,7 @@ func jsonMiddleware(next http.Handler) http.Handler {
 }
 
 func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
-	auth, err := util.ExtractAuthIDFromRequest(r.Header)
+	_, err := util.ExtractAuthIDFromRequest(r.Header)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusUnauthorized)
@@ -116,7 +110,6 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user, err := env.dao.CreateUser(dao.CreateUserInput{
-		AuthID: auth.ID,
 		Name:   req.Name,
 	})
 	if err != nil {
@@ -258,37 +251,4 @@ func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(struct{}{})
-}
-
-func (env *env) readUserAuthHandler(w http.ResponseWriter, r *http.Request) {
-	_, err := util.ExtractAuthIDFromRequest(r.Header)
-	if err != nil {
-		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusUnauthorized)
-		return
-	}
-
-	userID, err := util.ExtractIDFromRequest(mux.Vars(r))
-	if err != nil {
-		http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusBadRequest)
-		return
-	}
-
-	user, err := env.dao.ReadUser(dao.ReadUserInput{
-		ID: userID,
-	})
-	if err != nil {
-		switch err.(type) {
-		case dao.ErrUserNotFound:
-			http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusNotFound)
-		default:
-			errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
-			http.Error(w, errMsg, http.StatusInternalServerError)
-		}
-		return
-	}
-
-	json.NewEncoder(w).Encode(readUserAuthResponse{
-		AuthID: user.AuthID,
-	})
 }

--- a/user/user_it_test.go
+++ b/user/user_it_test.go
@@ -64,22 +64,6 @@ func TestIntegrationUser(t *testing.T) {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
 
-	// Read the auth for that same user
-	res, err = makeRequest(environment, http.MethodGet, "/user/1/auth", "", user1JWT)
-	if err != nil {
-		t.Fatalf("Could not make GET request: %s", err.Error())
-	}
-
-	if res.Code != http.StatusOK {
-		t.Errorf("Wrong status code: %v", res.Code)
-	}
-
-	received = res.Body.String()
-	expected = `{"AuthID":1}`
-	if expected != strings.TrimSuffix(received, "\n") {
-		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
-	}
-
 	// Update that same user
 	res, err = makeRequest(environment, http.MethodPut, "/user/1", `{"Name": "Lewis"}`, user1JWT)
 	if err != nil {

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -20,13 +20,11 @@ type mockDAO struct {
 func (md *mockDAO) CreateUser(input dao.CreateUserInput) (*dao.User, error) {
 	mockUser := dao.User{
 		ID:     int64(len(md.userList)),
-		AuthID: input.AuthID,
 		Name:   input.Name,
 	}
 	md.userList = append(md.userList, mockUser)
 	return &dao.User{
 		ID:     mockUser.ID,
-		AuthID: mockUser.AuthID,
 		Name:   mockUser.Name,
 	}, nil
 }
@@ -36,7 +34,6 @@ func (md *mockDAO) ReadUser(input dao.ReadUserInput) (*dao.User, error) {
 		if user.ID == input.ID {
 			return &dao.User{
 				ID:     user.ID,
-				AuthID: user.AuthID,
 				Name:   user.Name,
 			}, nil
 		}
@@ -50,7 +47,6 @@ func (md *mockDAO) UpdateUser(input dao.UpdateUserInput) (*dao.User, error) {
 			md.userList[i].Name = user.Name
 			return &dao.User{
 				ID:     user.ID,
-				AuthID: user.AuthID,
 				Name:   input.Name,
 			}, nil
 		}
@@ -574,98 +570,3 @@ func TestDeleteUserHandlerFailsOnDifferentJWT(t *testing.T) {
 	}
 }
 
-// Test that a single user can be successfully created and then auth read back
-func TestReadUserAuthHandlerSucceeds(t *testing.T) {
-	mockEnv := env{
-		&mockDAO{userList: make([]dao.User, 0)},
-	}
-
-	// Create a single user
-	_, err := makeRequest(mockEnv, http.MethodPost, "/user", `{"Name": "Jay"}`, user0JWT)
-	if err != nil {
-		t.Fatalf("Could not make POST request: %s", err.Error())
-	}
-
-	// Read that same user
-	res, err := makeRequest(mockEnv, http.MethodGet, "/user/0/auth", "", user0JWT)
-	if err != nil {
-		t.Fatalf("Could not make GET request: %s", err.Error())
-	}
-
-	if res.Code != http.StatusOK {
-		t.Errorf("Wrong status code: %v", res.Code)
-	}
-
-	received := res.Body.String()
-	expected := `{"AuthID":0}`
-	if expected != strings.TrimSuffix(received, "\n") {
-		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
-	}
-}
-
-// Test that providing no ID to the read auth endpoint fails
-func TestReadUserAuthHandlerFailsOnEmptyID(t *testing.T) {
-	mockEnv := env{
-		&mockDAO{userList: make([]dao.User, 0)},
-	}
-
-	res, err := makeRequest(mockEnv, http.MethodGet, "/user/auth", "", user0JWT)
-	if err != nil {
-		t.Fatalf("Could not make request: %s", err.Error())
-	}
-
-	// Bad request, since auth is interpreted as an ID
-	if res.Code != http.StatusBadRequest {
-		t.Errorf("Wrong status code: %v", res.Code)
-	}
-}
-
-// Test that providing a non-existent ID to the read auth endpoint fails
-func TestReadUserAuthHandlerFailsOnNonExistentID(t *testing.T) {
-	mockEnv := env{
-		&mockDAO{userList: make([]dao.User, 0)},
-	}
-
-	res, err := makeRequest(mockEnv, http.MethodGet, "/user/123456/auth", "", user0JWT)
-	if err != nil {
-		t.Fatalf("Could not make request: %s", err.Error())
-	}
-
-	// Not Found, since no user exists with that given ID
-	if res.Code != http.StatusNotFound {
-		t.Errorf("Wrong status code: %v", res.Code)
-	}
-}
-
-// Test that providing a string ID to the read auth endpoint fails
-func TestReadUserAuthHandlerFailsOnStringID(t *testing.T) {
-	mockEnv := env{
-		&mockDAO{userList: make([]dao.User, 0)},
-	}
-
-	res, err := makeRequest(mockEnv, http.MethodGet, "/user/abcdef/auth", "", user0JWT)
-	if err != nil {
-		t.Fatalf("Could not make request: %s", err.Error())
-	}
-
-	// Bad request, since we require an integer
-	if res.Code != http.StatusBadRequest {
-		t.Errorf("Wrong status code: %v", res.Code)
-	}
-}
-
-// Test that providing an empty JWT to the read endpoint fails
-func TestReadUserAuthHandlerFailsOnEmptyJWT(t *testing.T) {
-	mockEnv := env{
-		&mockDAO{userList: make([]dao.User, 0)},
-	}
-
-	res, err := makeRequest(mockEnv, http.MethodGet, "/user/0/auth", "", "")
-	if err != nil {
-		t.Fatalf("Could not make request: %s", err.Error())
-	}
-
-	if res.Code != http.StatusUnauthorized {
-		t.Errorf("Wrong status code: %v", res.Code)
-	}
-}


### PR DESCRIPTION
So.. it turns out keeping `auth` and `user` separated is going to be more problematic than I first anticipated. Our approach going forward is outlined in an internal document, however, the first step in achieving that is to remove the `authID` from storage. 

Unit & Integration tests still pass.