### PR TITLE
[user][auth] Use ID from JWT when storing user

### DIFF
--- a/api/spec-golang.openapi.yaml
+++ b/api/spec-golang.openapi.yaml
@@ -170,6 +170,7 @@ paths:
                 properties:
                   ID:
                     type: string 
+                    format: uuid
                   Name:
                     type: string
         400:
@@ -191,6 +192,7 @@ paths:
                 properties:
                   ID:
                     type: string 
+                    format: uuid
                   Name:
                     type: string
         400:
@@ -240,7 +242,8 @@ paths:
                 type: object
                 properties:
                   ID:
-                    type: string 
+                    type: string
+                    format: uuid
                   Name:
                     type: string
         400:

--- a/api/spec-golang.openapi.yaml
+++ b/api/spec-golang.openapi.yaml
@@ -169,7 +169,7 @@ paths:
                 type: object
                 properties:
                   ID:
-                    type: integer
+                    type: string 
                   Name:
                     type: string
         400:
@@ -190,7 +190,7 @@ paths:
                 type: object
                 properties:
                   ID:
-                    type: integer
+                    type: string 
                   Name:
                     type: string
         400:
@@ -240,7 +240,7 @@ paths:
                 type: object
                 properties:
                   ID:
-                    type: integer
+                    type: string 
                   Name:
                     type: string
         400:

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -196,7 +197,7 @@ func (env *env) readAuthHandler(w http.ResponseWriter, r *http.Request) {
 // Create an access token with a 24 hour lifetime
 func createToken(id int, issuer string, secret string) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"id":  id,
+		"id":  strconv.Itoa(id),
 		"iss": issuer,
 		"exp": time.Now().Add(24 * time.Hour).Unix(),
 	})

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -116,7 +116,7 @@ func TestCreateAuthHandlerSucceeds(t *testing.T) {
 		t.Fatalf("Claims doesn't contain an ID key")
 	}
 
-	if id.(float64) != 0 {
+	if id.(string) != "0" {
 		t.Fatalf("ID is incorrect, found: %+v, wanted: 0", id)
 	}
 
@@ -272,7 +272,7 @@ func TestReadAuthHandlerSucceeds(t *testing.T) {
 		t.Fatalf("Claims doesn't contain an ID key")
 	}
 
-	if id.(float64) != 0 {
+	if id.(string) != "0" {
 		t.Fatalf("ID is incorrect, found: %+v, wanted: 0", id)
 	}
 

--- a/user-db/init.sql
+++ b/user-db/init.sql
@@ -1,4 +1,4 @@
 CREATE TABLE user_temple (
-    id uuid PRIMARY KEY,
+    id UUID PRIMARY KEY,
     name TEXT
 );

--- a/user-db/init.sql
+++ b/user-db/init.sql
@@ -1,4 +1,4 @@
 CREATE TABLE user_temple (
-    id TEXT PRIMARY KEY,
+    id uuid PRIMARY KEY,
     name TEXT
 );

--- a/user-db/init.sql
+++ b/user-db/init.sql
@@ -1,4 +1,4 @@
 CREATE TABLE user_temple (
-    id SERIAL PRIMARY KEY,
+    id TEXT PRIMARY KEY,
     name TEXT
 );

--- a/user/dao/dao.go
+++ b/user/dao/dao.go
@@ -7,6 +7,7 @@ import (
 	"github.com/TempleEight/spec-golang/user/util"
 	// pq acts as the driver for SQL requests
 	_ "github.com/lib/pq"
+	uuid "github.com/satori/go.uuid"
 )
 
 // Datastore provides the interface adopted by the DAO, allowing for mocking
@@ -24,30 +25,30 @@ type DAO struct {
 
 // User encapsulates the object stored in the datastore
 type User struct {
-	ID   string
+	ID   uuid.UUID
 	Name string
 }
 
 // CreateUserInput encapsulates the information required to create a single user in the datastore
 type CreateUserInput struct {
-	ID   string
+	ID   uuid.UUID
 	Name string
 }
 
 // ReadUserInput encapsulates the information required to read a single user in the datastore
 type ReadUserInput struct {
-	ID string
+	ID uuid.UUID
 }
 
 // UpdateUserInput encapsulates the information required to update a single user in the datastore
 type UpdateUserInput struct {
-	ID   string
+	ID   uuid.UUID
 	Name string
 }
 
 // DeleteUserInput encapsulates the information required to delete a single user in the datastore
 type DeleteUserInput struct {
-	ID string
+	ID uuid.UUID
 }
 
 // Init opens the datastore connection, returning a DAO
@@ -97,7 +98,7 @@ func (dao *DAO) ReadUser(input ReadUserInput) (*User, error) {
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
-			return nil, ErrUserNotFound(input.ID)
+			return nil, ErrUserNotFound(input.ID.String())
 		default:
 			return nil, err
 		}
@@ -115,7 +116,7 @@ func (dao *DAO) UpdateUser(input UpdateUserInput) (*User, error) {
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
-			return nil, ErrUserNotFound(input.ID)
+			return nil, ErrUserNotFound(input.ID.String())
 		default:
 			return nil, err
 		}
@@ -130,7 +131,7 @@ func (dao *DAO) DeleteUser(input DeleteUserInput) error {
 	if err != nil {
 		return err
 	} else if rowsAffected == 0 {
-		return ErrUserNotFound(input.ID)
+		return ErrUserNotFound(input.ID.String())
 	}
 
 	return nil

--- a/user/dao/dao.go
+++ b/user/dao/dao.go
@@ -24,29 +24,30 @@ type DAO struct {
 
 // User encapsulates the object stored in the datastore
 type User struct {
-	ID     int64
-	Name   string
+	ID   string
+	Name string
 }
 
 // CreateUserInput encapsulates the information required to create a single user in the datastore
 type CreateUserInput struct {
-	Name   string
+	ID   string
+	Name string
 }
 
 // ReadUserInput encapsulates the information required to read a single user in the datastore
 type ReadUserInput struct {
-	ID int64
+	ID string
 }
 
 // UpdateUserInput encapsulates the information required to update a single user in the datastore
 type UpdateUserInput struct {
-	ID   int64
+	ID   string
 	Name string
 }
 
 // DeleteUserInput encapsulates the information required to delete a single user in the datastore
 type DeleteUserInput struct {
-	ID int64
+	ID string
 }
 
 // Init opens the datastore connection, returning a DAO
@@ -76,7 +77,7 @@ func executeQueryWithRowResponse(db *sql.DB, query string, args ...interface{}) 
 
 // CreateUser creates a new user in the datastore, returning the newly created user
 func (dao *DAO) CreateUser(input CreateUserInput) (*User, error) {
-	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO user_temple (name) VALUES ($1) RETURNING *", input.Name)
+	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO user_temple (id, name) VALUES ($1, $2) RETURNING *", input.ID, input.Name)
 
 	var user User
 	err := row.Scan(&user.ID, &user.Name)

--- a/user/dao/errors.go
+++ b/user/dao/errors.go
@@ -3,8 +3,8 @@ package dao
 import "fmt"
 
 // ErrUserNotFound is returned when a user for the provided ID was not found
-type ErrUserNotFound int64
+type ErrUserNotFound string
 
 func (e ErrUserNotFound) Error() string {
-	return fmt.Sprintf("user not found with ID %d", e)
+	return fmt.Sprintf("user not found with ID %s", string(e))
 }

--- a/user/go.mod
+++ b/user/go.mod
@@ -7,4 +7,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/mux v1.7.4
 	github.com/lib/pq v1.3.0
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/satori/go.uuid v1.2.0
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/user/go.sum
+++ b/user/go.sum
@@ -4,5 +4,14 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/user/user.go
+++ b/user/user.go
@@ -31,19 +31,19 @@ type updateUserRequest struct {
 
 // createUserResponse contains a newly created user to be returned to the client
 type createUserResponse struct {
-	ID   string
+	ID   uuid.UUID
 	Name string
 }
 
 // readUserResponse contains a single user to be returned to the client
 type readUserResponse struct {
-	ID   string
+	ID   uuid.UUID
 	Name string
 }
 
 // updateUserResponse contains a newly updated user to be returned to the client
 type updateUserResponse struct {
-	ID   string
+	ID   uuid.UUID
 	Name string
 }
 
@@ -110,8 +110,15 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	uuid, err := uuid.FromString(auth.ID)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid uuid: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
 	user, err := env.dao.CreateUser(dao.CreateUserInput{
-		ID:   uuid.FromStringOrNil(auth.ID),
+		ID:   uuid,
 		Name: req.Name,
 	})
 	if err != nil {
@@ -121,7 +128,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(createUserResponse{
-		ID:   user.ID.String(),
+		ID:   user.ID,
 		Name: user.Name,
 	})
 }
@@ -140,8 +147,15 @@ func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	uuid, err := uuid.FromString(userID)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid uuid: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
 	user, err := env.dao.ReadUser(dao.ReadUserInput{
-		ID: uuid.FromStringOrNil(userID),
+		ID: uuid,
 	})
 	if err != nil {
 		switch err.(type) {
@@ -155,7 +169,7 @@ func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(readUserResponse{
-		ID:   user.ID.String(),
+		ID:   user.ID,
 		Name: user.Name,
 	})
 }
@@ -196,8 +210,15 @@ func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	uuid, err := uuid.FromString(userID)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid uuid: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
 	user, err := env.dao.UpdateUser(dao.UpdateUserInput{
-		ID:   uuid.FromStringOrNil(userID),
+		ID:   uuid,
 		Name: req.Name,
 	})
 	if err != nil {
@@ -212,7 +233,7 @@ func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(updateUserResponse{
-		ID:   user.ID.String(),
+		ID:   user.ID,
 		Name: user.Name,
 	})
 }
@@ -238,8 +259,15 @@ func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	uuid, err := uuid.FromString(userID)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid uuid: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+
 	err = env.dao.DeleteUser(dao.DeleteUserInput{
-		ID: uuid.FromStringOrNil(userID),
+		ID: uuid,
 	})
 	if err != nil {
 		switch err.(type) {

--- a/user/user.go
+++ b/user/user.go
@@ -30,19 +30,19 @@ type updateUserRequest struct {
 
 // createUserResponse contains a newly created user to be returned to the client
 type createUserResponse struct {
-	ID   int64
+	ID   string
 	Name string
 }
 
 // readUserResponse contains a single user to be returned to the client
 type readUserResponse struct {
-	ID   int64
+	ID   string
 	Name string
 }
 
 // updateUserResponse contains a newly updated user to be returned to the client
 type updateUserResponse struct {
-	ID   int64
+	ID   string
 	Name string
 }
 
@@ -87,7 +87,7 @@ func jsonMiddleware(next http.Handler) http.Handler {
 }
 
 func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
-	_, err := util.ExtractAuthIDFromRequest(r.Header)
+	auth, err := util.ExtractAuthIDFromRequest(r.Header)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusUnauthorized)
@@ -110,7 +110,8 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user, err := env.dao.CreateUser(dao.CreateUserInput{
-		Name:   req.Name,
+		ID:   auth.ID,
+		Name: req.Name,
 	})
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))

--- a/user/user.go
+++ b/user/user.go
@@ -110,15 +110,8 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	uuid, err := uuid.FromString(auth.ID)
-	if err != nil {
-		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid uuid: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusBadRequest)
-		return
-	}
-
 	user, err := env.dao.CreateUser(dao.CreateUserInput{
-		ID:   uuid,
+		ID:   auth.ID,
 		Name: req.Name,
 	})
 	if err != nil {
@@ -147,15 +140,8 @@ func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	uuid, err := uuid.FromString(userID)
-	if err != nil {
-		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid uuid: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusBadRequest)
-		return
-	}
-
 	user, err := env.dao.ReadUser(dao.ReadUserInput{
-		ID: uuid,
+		ID: userID,
 	})
 	if err != nil {
 		switch err.(type) {
@@ -210,15 +196,8 @@ func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	uuid, err := uuid.FromString(userID)
-	if err != nil {
-		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid uuid: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusBadRequest)
-		return
-	}
-
 	user, err := env.dao.UpdateUser(dao.UpdateUserInput{
-		ID:   uuid,
+		ID:   userID,
 		Name: req.Name,
 	})
 	if err != nil {
@@ -259,15 +238,8 @@ func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	uuid, err := uuid.FromString(userID)
-	if err != nil {
-		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid uuid: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusBadRequest)
-		return
-	}
-
 	err = env.dao.DeleteUser(dao.DeleteUserInput{
-		ID: uuid,
+		ID: userID,
 	})
 	if err != nil {
 		switch err.(type) {

--- a/user/user.go
+++ b/user/user.go
@@ -11,6 +11,7 @@ import (
 	"github.com/TempleEight/spec-golang/user/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/gorilla/mux"
+	uuid "github.com/satori/go.uuid"
 )
 
 // env defines the environment that requests should be executed within
@@ -110,7 +111,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user, err := env.dao.CreateUser(dao.CreateUserInput{
-		ID:   auth.ID,
+		ID:   uuid.FromStringOrNil(auth.ID),
 		Name: req.Name,
 	})
 	if err != nil {
@@ -120,7 +121,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(createUserResponse{
-		ID:   user.ID,
+		ID:   user.ID.String(),
 		Name: user.Name,
 	})
 }
@@ -140,7 +141,7 @@ func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user, err := env.dao.ReadUser(dao.ReadUserInput{
-		ID: userID,
+		ID: uuid.FromStringOrNil(userID),
 	})
 	if err != nil {
 		switch err.(type) {
@@ -154,7 +155,7 @@ func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(readUserResponse{
-		ID:   user.ID,
+		ID:   user.ID.String(),
 		Name: user.Name,
 	})
 }
@@ -196,7 +197,7 @@ func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user, err := env.dao.UpdateUser(dao.UpdateUserInput{
-		ID:   userID,
+		ID:   uuid.FromStringOrNil(userID),
 		Name: req.Name,
 	})
 	if err != nil {
@@ -211,7 +212,7 @@ func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(updateUserResponse{
-		ID:   user.ID,
+		ID:   user.ID.String(),
 		Name: user.Name,
 	})
 }
@@ -238,7 +239,7 @@ func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err = env.dao.DeleteUser(dao.DeleteUserInput{
-		ID: userID,
+		ID: uuid.FromStringOrNil(userID),
 	})
 	if err != nil {
 		switch err.(type) {

--- a/user/user_it_test.go
+++ b/user/user_it_test.go
@@ -43,7 +43,7 @@ func TestIntegrationUser(t *testing.T) {
 	}
 
 	received := res.Body.String()
-	expected := `{"ID":1,"Name":"Jay"}`
+	expected := `{"ID":"1","Name":"Jay"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
@@ -59,7 +59,7 @@ func TestIntegrationUser(t *testing.T) {
 	}
 
 	received = res.Body.String()
-	expected = `{"ID":1,"Name":"Jay"}`
+	expected = `{"ID":"1","Name":"Jay"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
@@ -75,7 +75,7 @@ func TestIntegrationUser(t *testing.T) {
 	}
 
 	received = res.Body.String()
-	expected = `{"ID":1,"Name":"Lewis"}`
+	expected = `{"ID":"1","Name":"Lewis"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}

--- a/user/user_it_test.go
+++ b/user/user_it_test.go
@@ -43,13 +43,13 @@ func TestIntegrationUser(t *testing.T) {
 	}
 
 	received := res.Body.String()
-	expected := `{"ID":"1","Name":"Jay"}`
+	expected := `{"ID":"00000000-0000-0000-0000-000000000000","Name":"Jay"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
 
 	// Read that same user
-	res, err = makeRequest(environment, http.MethodGet, "/user/1", "", user1JWT)
+	res, err = makeRequest(environment, http.MethodGet, "/user/0", "", user1JWT)
 	if err != nil {
 		t.Fatalf("Could not make GET request: %s", err.Error())
 	}
@@ -59,13 +59,13 @@ func TestIntegrationUser(t *testing.T) {
 	}
 
 	received = res.Body.String()
-	expected = `{"ID":"1","Name":"Jay"}`
+	expected = `{"ID":"00000000-0000-0000-0000-000000000000","Name":"Jay"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
 
 	// Update that same user
-	res, err = makeRequest(environment, http.MethodPut, "/user/1", `{"Name": "Lewis"}`, user1JWT)
+	res, err = makeRequest(environment, http.MethodPut, "/user/0", `{"Name": "Lewis"}`, user1JWT)
 	if err != nil {
 		t.Fatalf("Could not make PUT request: %s", err.Error())
 	}
@@ -75,13 +75,13 @@ func TestIntegrationUser(t *testing.T) {
 	}
 
 	received = res.Body.String()
-	expected = `{"ID":"1","Name":"Lewis"}`
+	expected = `{"ID":"00000000-0000-0000-0000-000000000000","Name":"Lewis"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
 
 	// Delete that same user
-	res, err = makeRequest(environment, http.MethodDelete, "/user/1", "", user1JWT)
+	res, err = makeRequest(environment, http.MethodDelete, "/user/0", "", user1JWT)
 	if err != nil {
 		t.Fatalf("Could not make DELETE request: %s", err.Error())
 	}

--- a/user/user_it_test.go
+++ b/user/user_it_test.go
@@ -43,13 +43,13 @@ func TestIntegrationUser(t *testing.T) {
 	}
 
 	received := res.Body.String()
-	expected := `{"ID":"00000000-0000-0000-0000-000000000000","Name":"Jay"}`
+	expected := `{"ID":"00000000-1234-5678-9012-000000000001","Name":"Jay"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
 
 	// Read that same user
-	res, err = makeRequest(environment, http.MethodGet, "/user/0", "", user1JWT)
+	res, err = makeRequest(environment, http.MethodGet, "/user/00000000-1234-5678-9012-000000000001", "", user1JWT)
 	if err != nil {
 		t.Fatalf("Could not make GET request: %s", err.Error())
 	}
@@ -59,13 +59,13 @@ func TestIntegrationUser(t *testing.T) {
 	}
 
 	received = res.Body.String()
-	expected = `{"ID":"00000000-0000-0000-0000-000000000000","Name":"Jay"}`
+	expected = `{"ID":"00000000-1234-5678-9012-000000000001","Name":"Jay"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
 
 	// Update that same user
-	res, err = makeRequest(environment, http.MethodPut, "/user/0", `{"Name": "Lewis"}`, user1JWT)
+	res, err = makeRequest(environment, http.MethodPut, "/user/00000000-1234-5678-9012-000000000001", `{"Name": "Lewis"}`, user1JWT)
 	if err != nil {
 		t.Fatalf("Could not make PUT request: %s", err.Error())
 	}
@@ -75,13 +75,13 @@ func TestIntegrationUser(t *testing.T) {
 	}
 
 	received = res.Body.String()
-	expected = `{"ID":"00000000-0000-0000-0000-000000000000","Name":"Lewis"}`
+	expected = `{"ID":"00000000-1234-5678-9012-000000000001","Name":"Lewis"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
 
 	// Delete that same user
-	res, err = makeRequest(environment, http.MethodDelete, "/user/0", "", user1JWT)
+	res, err = makeRequest(environment, http.MethodDelete, "/user/00000000-1234-5678-9012-000000000001", "", user1JWT)
 	if err != nil {
 		t.Fatalf("Could not make DELETE request: %s", err.Error())
 	}

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -216,7 +216,7 @@ func TestReadUserHandlerFailsOnNonExistentID(t *testing.T) {
 		&mockDAO{userList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodGet, "/user/123456", "", user0JWT)
+	res, err := makeRequest(mockEnv, http.MethodGet, "/user/00000000-0000-0000-0000-000000000000", "", user0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
@@ -364,7 +364,7 @@ func TestUpdateUserHandlerFailsOnNonExistentID(t *testing.T) {
 		&mockDAO{userList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/123456", `{"Name":"Will"}`, user0JWT)
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/00000000-0000-0000-0000-000000000000", `{"Name":"Will"}`, user0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
@@ -466,7 +466,7 @@ func TestDeleteUserHandlerFailsOnNonExistentID(t *testing.T) {
 		&mockDAO{userList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/123456", "", user0JWT)
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/00000000-0000-0000-0000-000000000000", "", user0JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 // Define 2 JWTs with ID 0 and 1
-const user0JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1ODMyNTc5NzcsImlkIjoiMCIsImlzcyI6ImZGUzhLbVZZdUtBQ3lGM3dkcFBLSFNRcW1aVlZ3akRxIn0.FohTyHoXuX2PO8oLSxRczq_Lca2UoYPiruBC2p9psOk"
-const user1JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1ODMyNTc5NzcsImlkIjoiMSIsImlzcyI6ImZGUzhLbVZZdUtBQ3lGM3dkcFBLSFNRcW1aVlZ3akRxIn0.zPtNhZAhfte8dBYNqfzfRf4HACeqk5kd_jw-sBfKnZ0"
+const user0JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1ODMyNTc5NzcsImlkIjoiMDAwMDAwMDAtMTIzNC01Njc4LTkwMTItMDAwMDAwMDAwMDAwIiwiaXNzIjoiZkZTOEttVll1S0FDeUYzd2RwUEtIU1FxbVpWVndqRHEifQ.jMpelsEJUwONtRCQnQCo2v5Ph7cZHloc5R1OvKkU2Ck"
+const user1JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1ODMyNTc5NzcsImlkIjoiMDAwMDAwMDAtMTIzNC01Njc4LTkwMTItMDAwMDAwMDAwMDAxIiwiaXNzIjoiZkZTOEttVll1S0FDeUYzd2RwUEtIU1FxbVpWVndqRHEifQ.lMmkaK9L2kD2ZnbblSlXdz93cz6jZCALR0KoGlzQKpc"
 
 type mockDAO struct {
 	userList []dao.User
@@ -90,7 +90,7 @@ func TestCreateUserHandlerSucceeds(t *testing.T) {
 	}
 
 	received := res.Body.String()
-	expected := `{"ID":"00000000-0000-0000-0000-000000000000","Name":"Jay"}`
+	expected := `{"ID":"00000000-1234-5678-9012-000000000000","Name":"Jay"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
@@ -177,7 +177,7 @@ func TestReadUserHandlerSucceeds(t *testing.T) {
 	}
 
 	// Read that same user
-	res, err := makeRequest(mockEnv, http.MethodGet, "/user/0", "", user0JWT)
+	res, err := makeRequest(mockEnv, http.MethodGet, "/user/00000000-1234-5678-9012-000000000000", "", user0JWT)
 	if err != nil {
 		t.Fatalf("Could not make GET request: %s", err.Error())
 	}
@@ -187,7 +187,7 @@ func TestReadUserHandlerSucceeds(t *testing.T) {
 	}
 
 	received := res.Body.String()
-	expected := `{"ID":"00000000-0000-0000-0000-000000000000","Name":"Jay"}`
+	expected := `{"ID":"00000000-1234-5678-9012-000000000000","Name":"Jay"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
@@ -233,7 +233,7 @@ func TestReadUserHandlerFailsOnEmptyJWT(t *testing.T) {
 		&mockDAO{userList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodGet, "/user/0", `{"Name": "Jay"}`, "")
+	res, err := makeRequest(mockEnv, http.MethodGet, "/user/00000000-1234-5678-9012-000000000000", `{"Name": "Jay"}`, "")
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
@@ -256,7 +256,7 @@ func TestUpdateUserHandlerSucceeds(t *testing.T) {
 	}
 
 	// Update that same user
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name": "Lewis"}`, user0JWT)
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/00000000-1234-5678-9012-000000000000", `{"Name": "Lewis"}`, user0JWT)
 	if err != nil {
 		t.Fatalf("Could not make PUT request: %s", err.Error())
 	}
@@ -266,7 +266,7 @@ func TestUpdateUserHandlerSucceeds(t *testing.T) {
 	}
 
 	received := res.Body.String()
-	expected := `{"ID":"00000000-0000-0000-0000-000000000000","Name":"Lewis"}`
+	expected := `{"ID":"00000000-1234-5678-9012-000000000000","Name":"Lewis"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
@@ -285,7 +285,7 @@ func TestUpdateUserHandlerFailsOnEmptyParameter(t *testing.T) {
 	}
 
 	// Update that same user
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name": ""}`, user0JWT)
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/00000000-1234-5678-9012-000000000000", `{"Name": ""}`, user0JWT)
 	if err != nil {
 		t.Fatalf("Could not make PUT request: %s", err.Error())
 	}
@@ -308,7 +308,7 @@ func TestUpdateUserHandlerFailsOnMalformedJSONBody(t *testing.T) {
 	}
 
 	// Update that same user
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name"}`, user0JWT)
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/00000000-1234-5678-9012-000000000000", `{"Name"}`, user0JWT)
 	if err != nil {
 		t.Fatalf("Could not make PUT request: %s", err.Error())
 	}
@@ -331,7 +331,7 @@ func TestUpdateUserHandlerFailsOnNoBody(t *testing.T) {
 	}
 
 	// Update that same user
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", "", user0JWT)
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/00000000-1234-5678-9012-000000000000", "", user0JWT)
 	if err != nil {
 		t.Fatalf("Could not make PUT request: %s", err.Error())
 	}
@@ -381,7 +381,7 @@ func TestUpdateUserHandlerFailsOnEmptyJWT(t *testing.T) {
 		&mockDAO{userList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name": "Jay"}`, "")
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/00000000-1234-5678-9012-000000000000", `{"Name": "Jay"}`, "")
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
@@ -404,7 +404,7 @@ func TestUpdateUserHandlerFailsOnDifferentJWT(t *testing.T) {
 	}
 
 	// Update a single user with user1JWT
-	res, err := makeRequest(mockEnv, http.MethodPut, "/user/0", `{"Name": "Lewis"}`, user1JWT)
+	res, err := makeRequest(mockEnv, http.MethodPut, "/user/00000000-1234-5678-9012-000000000000", `{"Name": "Lewis"}`, user1JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
@@ -427,7 +427,7 @@ func TestDeleteUserHandlerSucceeds(t *testing.T) {
 	}
 
 	// Delete that same user
-	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/0", "", user0JWT)
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/00000000-1234-5678-9012-000000000000", "", user0JWT)
 	if err != nil {
 		t.Fatalf("Could not make DELETE request: %s", err.Error())
 	}
@@ -483,7 +483,7 @@ func TestDeleteUserHandlerFailsOnEmptyJWT(t *testing.T) {
 		&mockDAO{userList: make([]dao.User, 0)},
 	}
 
-	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/0", "", "")
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/00000000-1234-5678-9012-000000000000", "", "")
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}
@@ -506,7 +506,7 @@ func TestDeleteUserHandlerFailsOnDifferentJWT(t *testing.T) {
 	}
 
 	// Delete a single user with user1JWT
-	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/0", "", user1JWT)
+	res, err := makeRequest(mockEnv, http.MethodDelete, "/user/00000000-1234-5678-9012-000000000000", "", user1JWT)
 	if err != nil {
 		t.Fatalf("Could not make request: %s", err.Error())
 	}

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -35,7 +35,7 @@ func (md *mockDAO) ReadUser(input dao.ReadUserInput) (*dao.User, error) {
 			}, nil
 		}
 	}
-	return nil, dao.ErrUserNotFound(input.ID)
+	return nil, dao.ErrUserNotFound(input.ID.String())
 }
 
 func (md *mockDAO) UpdateUser(input dao.UpdateUserInput) (*dao.User, error) {
@@ -48,7 +48,7 @@ func (md *mockDAO) UpdateUser(input dao.UpdateUserInput) (*dao.User, error) {
 			}, nil
 		}
 	}
-	return nil, dao.ErrUserNotFound(input.ID)
+	return nil, dao.ErrUserNotFound(input.ID.String())
 }
 
 func (md *mockDAO) DeleteUser(input dao.DeleteUserInput) error {
@@ -58,7 +58,7 @@ func (md *mockDAO) DeleteUser(input dao.DeleteUserInput) error {
 			return nil
 		}
 	}
-	return dao.ErrUserNotFound(input.ID)
+	return dao.ErrUserNotFound(input.ID.String())
 }
 
 func makeRequest(env env, method string, url string, body string, authToken string) (*httptest.ResponseRecorder, error) {
@@ -90,7 +90,7 @@ func TestCreateUserHandlerSucceeds(t *testing.T) {
 	}
 
 	received := res.Body.String()
-	expected := `{"ID":"0","Name":"Jay"}`
+	expected := `{"ID":"00000000-0000-0000-0000-000000000000","Name":"Jay"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
@@ -187,7 +187,7 @@ func TestReadUserHandlerSucceeds(t *testing.T) {
 	}
 
 	received := res.Body.String()
-	expected := `{"ID":"0","Name":"Jay"}`
+	expected := `{"ID":"00000000-0000-0000-0000-000000000000","Name":"Jay"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}
@@ -266,7 +266,7 @@ func TestUpdateUserHandlerSucceeds(t *testing.T) {
 	}
 
 	received := res.Body.String()
-	expected := `{"ID":"0","Name":"Lewis"}`
+	expected := `{"ID":"00000000-0000-0000-0000-000000000000","Name":"Lewis"}`
 	if expected != strings.TrimSuffix(received, "\n") {
 		t.Errorf("Handler returned incorrect body: got %+v want %+v", received, expected)
 	}

--- a/user/util/util.go
+++ b/user/util/util.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 
 	"github.com/dgrijalva/jwt-go"
+	uuid "github.com/satori/go.uuid"
 )
 
 // Auth contains the unique identifier for a given auth
 type Auth struct {
-	ID string
+	ID uuid.UUID
 }
 
 // GetConfig returns a configuration object from decoding the given configuration file
@@ -42,13 +43,13 @@ func CreateErrorJSON(message string) string {
 }
 
 // ExtractIDFromRequest extracts the parameter provided under parameter ID and converts it into a string
-func ExtractIDFromRequest(requestParams map[string]string) (string, error) {
+func ExtractIDFromRequest(requestParams map[string]string) (uuid.UUID, error) {
 	id := requestParams["id"]
 	if len(id) == 0 {
-		return "", errors.New("No ID provided")
+		return uuid.Nil, errors.New("No ID provided")
 	}
 
-	return id, nil
+	return uuid.FromString(id)
 }
 
 // ExtractAuthIDFromRequest extracts a token from a header of the form `Authorization: Bearer <token>`
@@ -78,5 +79,10 @@ func ExtractAuthIDFromRequest(headers http.Header) (*Auth, error) {
 		return nil, errors.New("JWT does not contain an id")
 	}
 
-	return &Auth{id.(string)}, nil
+	uuid, err := uuid.FromString(id.(string))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Auth{uuid}, nil
 }

--- a/user/util/util.go
+++ b/user/util/util.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/dgrijalva/jwt-go"
@@ -13,7 +12,7 @@ import (
 
 // Auth contains the unique identifier for a given auth
 type Auth struct {
-	ID int64
+	ID string
 }
 
 // GetConfig returns a configuration object from decoding the given configuration file
@@ -42,16 +41,11 @@ func CreateErrorJSON(message string) string {
 	return string(json)
 }
 
-// ExtractIDFromRequest extracts the parameter provided under parameter ID and converts it into an integer
-func ExtractIDFromRequest(requestParams map[string]string) (int64, error) {
-	idStr := requestParams["id"]
-	if len(idStr) == 0 {
-		return 0, errors.New("No ID provided")
-	}
-
-	id, err := strconv.ParseInt(idStr, 10, 64)
-	if err != nil {
-		return 0, errors.New("Invalid ID provided")
+// ExtractIDFromRequest extracts the parameter provided under parameter ID and converts it into a string
+func ExtractIDFromRequest(requestParams map[string]string) (string, error) {
+	id := requestParams["id"]
+	if len(id) == 0 {
+		return "", errors.New("No ID provided")
 	}
 
 	return id, nil
@@ -84,11 +78,5 @@ func ExtractAuthIDFromRequest(headers http.Header) (*Auth, error) {
 		return nil, errors.New("JWT does not contain an id")
 	}
 
-	// Convert to an integer
-	intID, err := id.(json.Number).Int64()
-	if err != nil {
-		return nil, err
-	}
-
-	return &Auth{intID}, nil
+	return &Auth{id.(string)}, nil
 }


### PR DESCRIPTION
- Use the ID provided in the JWT as the primary key for the user table
- Convert ID from int to string in preparation for using UUIDs
- Remove redundant tests about providing a string ID

#### Test Plan
- Existing unit and integration tests updated
- Manual testing:

```
❯❯❯ TOKEN=$(curl -s -X POST localhost:8000/api/auth -d '{"email":"jay@test.com", "password":"BlackcurrantCrush123"}')

❯❯❯ curl -X POST localhost:8000/api/user -d '{"name": "Jay"}' -H "Authorization: Bearer $TOKEN"
{"ID":"1","Name":"Jay"}

❯❯❯ curl -X GET localhost:8000/api/user/1 -H "Authorization: Bearer $TOKEN"
{"ID":"1","Name":"Jay"}
```