### PR TITLE
[go-gen] Add auth to the Match service

### DIFF
--- a/auth-db/init.sql
+++ b/auth-db/init.sql
@@ -1,5 +1,5 @@
 CREATE TABLE auth (
-    id SERIAL PRIMARY KEY,
-    email TEXT UNIQUE,
-    password TEXT
+  id SERIAL PRIMARY KEY,
+  email TEXT UNIQUE,
+  password TEXT
 );

--- a/match-db/init.sql
+++ b/match-db/init.sql
@@ -1,5 +1,6 @@
 CREATE TABLE match (
     id SERIAL PRIMARY KEY,
+    auth_id INT NOT NULL,
     userOne int,
     userTwo int,
     matchedOn timestamp

--- a/match-db/init.sql
+++ b/match-db/init.sql
@@ -1,7 +1,7 @@
 CREATE TABLE match (
-    id SERIAL PRIMARY KEY,
-    auth_id INT NOT NULL,
-    userOne int,
-    userTwo int,
-    matchedOn timestamp
-  );
+  id SERIAL PRIMARY KEY,
+  auth_id INT NOT NULL,
+  userOne INT,
+  userTwo INT,
+  matchedOn TIMESTAMP,
+);

--- a/match/dao/dao.go
+++ b/match/dao/dao.go
@@ -11,7 +11,7 @@ import (
 
 // Datastore provides the interface adopted by the DAO, allowing for mocking
 type Datastore interface {
-	ListMatch() (*[]Match, error)
+	ListMatch(input ListMatchInput) (*[]Match, error)
 	CreateMatch(input CreateMatchInput) (*Match, error)
 	ReadMatch(input ReadMatchInput) (*Match, error)
 	UpdateMatch(input UpdateMatchInput) (*Match, error)
@@ -30,6 +30,11 @@ type Match struct {
 	UserOne   int64
 	UserTwo   int64
 	MatchedOn string
+}
+
+// ListMatchInput encapsulates the information required to read a match list in the datastore
+type ListMatchInput struct {
+	AuthID int64
 }
 
 // CreateMatchInput encapsulates the information required to create a single match in the datastore
@@ -87,9 +92,9 @@ func executeQueryWithRowResponses(db *sql.DB, query string, args ...interface{})
 	return db.Query(query, args...)
 }
 
-// ListMatch returns a list containing every match in the datastore
-func (dao *DAO) ListMatch() (*[]Match, error) {
-	rows, err := executeQueryWithRowResponses(dao.DB, "SELECT * FROM Match")
+// ListMatch returns a list containing every match in the datastore for a given ID
+func (dao *DAO) ListMatch(input ListMatchInput) (*[]Match, error) {
+	rows, err := executeQueryWithRowResponses(dao.DB, "SELECT * FROM Match WHERE id = $1", input.AuthID)
 	if err != nil {
 		return nil, err
 	}

--- a/match/dao/dao.go
+++ b/match/dao/dao.go
@@ -119,7 +119,7 @@ func (dao *DAO) ListMatch(input ListMatchInput) (*[]Match, error) {
 
 // CreateMatch creates a new match in the datastore, returning the newly created match
 func (dao *DAO) CreateMatch(input CreateMatchInput) (*Match, error) {
-	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO match (auth_id, userOne, userTwo, matchedOn) VALUES ($1, $2, NOW()) RETURNING *", input.UserOne, input.UserTwo)
+	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO match (auth_id, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, NOW()) RETURNING *", input.AuthID, input.UserOne, input.UserTwo)
 
 	var match Match
 	err := row.Scan(&match.ID, &match.AuthID, &match.UserOne, &match.UserTwo, &match.MatchedOn)

--- a/match/dao/dao.go
+++ b/match/dao/dao.go
@@ -26,6 +26,7 @@ type DAO struct {
 // Match encapsulates the object stored in the datastore
 type Match struct {
 	ID        int64
+	AuthID    int64
 	UserOne   int64
 	UserTwo   int64
 	MatchedOn string
@@ -33,6 +34,7 @@ type Match struct {
 
 // CreateMatchInput encapsulates the information required to create a single match in the datastore
 type CreateMatchInput struct {
+	AuthID  int64
 	UserOne int64
 	UserTwo int64
 }
@@ -95,7 +97,7 @@ func (dao *DAO) ListMatch() (*[]Match, error) {
 	matchList := make([]Match, 0)
 	for rows.Next() {
 		var match Match
-		err = rows.Scan(&match.ID, &match.UserOne, &match.UserTwo, &match.MatchedOn)
+		err = rows.Scan(&match.ID, &match.AuthID, &match.UserOne, &match.UserTwo, &match.MatchedOn)
 		if err != nil {
 			return nil, err
 		}
@@ -112,10 +114,10 @@ func (dao *DAO) ListMatch() (*[]Match, error) {
 
 // CreateMatch creates a new match in the datastore, returning the newly created match
 func (dao *DAO) CreateMatch(input CreateMatchInput) (*Match, error) {
-	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO match (userOne, userTwo, matchedOn) VALUES ($1, $2, NOW()) RETURNING *", input.UserOne, input.UserTwo)
+	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO match (auth_id, userOne, userTwo, matchedOn) VALUES ($1, $2, NOW()) RETURNING *", input.UserOne, input.UserTwo)
 
 	var match Match
-	err := row.Scan(&match.ID, &match.UserOne, &match.UserTwo, &match.MatchedOn)
+	err := row.Scan(&match.ID, &match.AuthID, &match.UserOne, &match.UserTwo, &match.MatchedOn)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +130,7 @@ func (dao *DAO) ReadMatch(input ReadMatchInput) (*Match, error) {
 	row := executeQueryWithRowResponse(dao.DB, "SELECT * FROM match WHERE id = $1", input.ID)
 
 	var match Match
-	err := row.Scan(&match.ID, &match.UserOne, &match.UserTwo, &match.MatchedOn)
+	err := row.Scan(&match.ID, &match.AuthID, &match.UserOne, &match.UserTwo, &match.MatchedOn)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
@@ -146,7 +148,7 @@ func (dao *DAO) UpdateMatch(input UpdateMatchInput) (*Match, error) {
 	row := executeQueryWithRowResponse(dao.DB, "UPDATE match SET userOne = $1, userTwo = $2, matchedOn = NOW() WHERE id = $3 RETURNING *", input.UserOne, input.UserTwo, input.ID)
 
 	var match Match
-	err := row.Scan(&match.ID, &match.UserOne, &match.UserTwo, &match.MatchedOn)
+	err := row.Scan(&match.ID, &match.AuthID, &match.UserOne, &match.UserTwo, &match.MatchedOn)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/match/dao/dao.go
+++ b/match/dao/dao.go
@@ -94,7 +94,7 @@ func executeQueryWithRowResponses(db *sql.DB, query string, args ...interface{})
 
 // ListMatch returns a list containing every match in the datastore for a given ID
 func (dao *DAO) ListMatch(input ListMatchInput) (*[]Match, error) {
-	rows, err := executeQueryWithRowResponses(dao.DB, "SELECT * FROM Match WHERE id = $1", input.AuthID)
+	rows, err := executeQueryWithRowResponses(dao.DB, "SELECT * FROM match WHERE auth_id = $1", input.AuthID)
 	if err != nil {
 		return nil, err
 	}

--- a/match/go.mod
+++ b/match/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/mux v1.7.4
 	github.com/lib/pq v1.3.0
 )

--- a/match/go.sum
+++ b/match/go.sum
@@ -1,5 +1,7 @@
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=

--- a/match/match.go
+++ b/match/match.go
@@ -105,6 +105,21 @@ func jsonMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+func checkAuthorization(env *env, auth *util.Auth, matchID int64) (bool, error) {
+	match, err := env.dao.ReadMatch(dao.ReadMatchInput{
+		ID: matchID,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	if match.ID != auth.ID {
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func (env *env) listMatchHandler(w http.ResponseWriter, r *http.Request) {
 	matchList, err := env.dao.ListMatch()
 	if err != nil {
@@ -129,8 +144,15 @@ func (env *env) listMatchHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
+	auth, err := util.ExtractAuthIDFromRequest(r.Header)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		return
+	}
+
 	var req createMatchRequest
-	err := json.NewDecoder(r.Body).Decode(&req)
+	err = json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusBadRequest)
@@ -177,6 +199,7 @@ func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	match, err := env.dao.CreateMatch(dao.CreateMatchInput{
+		AuthID:  auth.ID,
 		UserOne: *req.UserOne,
 		UserTwo: *req.UserTwo,
 	})
@@ -195,9 +218,29 @@ func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (env *env) readMatchHandler(w http.ResponseWriter, r *http.Request) {
+	auth, err := util.ExtractAuthIDFromRequest(r.Header)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		return
+	}
+
 	matchID, err := util.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
 		http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusBadRequest)
+		return
+	}
+
+	authorized, err := checkAuthorization(env, auth, matchID)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	if !authorized {
+		errMsg := util.CreateErrorJSON("Unauthorized")
+		http.Error(w, errMsg, http.StatusUnauthorized)
 		return
 	}
 
@@ -224,9 +267,29 @@ func (env *env) readMatchHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (env *env) updateMatchHandler(w http.ResponseWriter, r *http.Request) {
+	auth, err := util.ExtractAuthIDFromRequest(r.Header)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		return
+	}
+
 	matchID, err := util.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
 		http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusBadRequest)
+		return
+	}
+
+	authorized, err := checkAuthorization(env, auth, matchID)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	if !authorized {
+		errMsg := util.CreateErrorJSON("Unauthorized")
+		http.Error(w, errMsg, http.StatusUnauthorized)
 		return
 	}
 
@@ -301,9 +364,29 @@ func (env *env) updateMatchHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (env *env) deleteMatchHandler(w http.ResponseWriter, r *http.Request) {
+	auth, err := util.ExtractAuthIDFromRequest(r.Header)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		return
+	}
+
 	matchID, err := util.ExtractIDFromRequest(mux.Vars(r))
 	if err != nil {
 		http.Error(w, util.CreateErrorJSON(err.Error()), http.StatusBadRequest)
+		return
+	}
+
+	authorized, err := checkAuthorization(env, auth, matchID)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	if !authorized {
+		errMsg := util.CreateErrorJSON("Unauthorized")
+		http.Error(w, errMsg, http.StatusUnauthorized)
 		return
 	}
 

--- a/match/match.go
+++ b/match/match.go
@@ -121,7 +121,16 @@ func checkAuthorization(env *env, auth *util.Auth, matchID int64) (bool, error) 
 }
 
 func (env *env) listMatchHandler(w http.ResponseWriter, r *http.Request) {
-	matchList, err := env.dao.ListMatch()
+	auth, err := util.ExtractAuthIDFromRequest(r.Header)
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		return
+	}
+
+	matchList, err := env.dao.ListMatch(dao.ListMatchInput{
+		AuthID: auth.ID,
+	})
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)

--- a/match/match.go
+++ b/match/match.go
@@ -113,11 +113,7 @@ func checkAuthorization(env *env, auth *util.Auth, matchID int64) (bool, error) 
 		return false, err
 	}
 
-	if match.ID != auth.ID {
-		return false, nil
-	}
-
-	return true, nil
+	return match.AuthID == auth.ID, nil
 }
 
 func (env *env) listMatchHandler(w http.ResponseWriter, r *http.Request) {
@@ -242,8 +238,14 @@ func (env *env) readMatchHandler(w http.ResponseWriter, r *http.Request) {
 
 	authorized, err := checkAuthorization(env, auth, matchID)
 	if err != nil {
-		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusInternalServerError)
+		switch err.(type) {
+		case dao.ErrMatchNotFound:
+			errMsg := util.CreateErrorJSON("Unauthorized")
+			http.Error(w, errMsg, http.StatusUnauthorized)
+		default:
+			errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+			http.Error(w, errMsg, http.StatusInternalServerError)
+		}
 		return
 	}
 
@@ -291,8 +293,14 @@ func (env *env) updateMatchHandler(w http.ResponseWriter, r *http.Request) {
 
 	authorized, err := checkAuthorization(env, auth, matchID)
 	if err != nil {
-		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusInternalServerError)
+		switch err.(type) {
+		case dao.ErrMatchNotFound:
+			errMsg := util.CreateErrorJSON("Unauthorized")
+			http.Error(w, errMsg, http.StatusUnauthorized)
+		default:
+			errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+			http.Error(w, errMsg, http.StatusInternalServerError)
+		}
 		return
 	}
 
@@ -388,8 +396,14 @@ func (env *env) deleteMatchHandler(w http.ResponseWriter, r *http.Request) {
 
 	authorized, err := checkAuthorization(env, auth, matchID)
 	if err != nil {
-		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
-		http.Error(w, errMsg, http.StatusInternalServerError)
+		switch err.(type) {
+		case dao.ErrMatchNotFound:
+			errMsg := util.CreateErrorJSON("Unauthorized")
+			http.Error(w, errMsg, http.StatusUnauthorized)
+		default:
+			errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
+			http.Error(w, errMsg, http.StatusInternalServerError)
+		}
 		return
 	}
 

--- a/match/match_test.go
+++ b/match/match_test.go
@@ -25,13 +25,7 @@ func (md *mockDAO) ListMatch(input dao.ListMatchInput) (*[]dao.Match, error) {
 	mockMatchList := make([]dao.Match, 0)
 	for _, match := range md.matchList {
 		if match.AuthID == input.AuthID {
-			mockMatchList = append(mockMatchList, dao.Match{
-				ID:        match.ID,
-				AuthID:    match.AuthID,
-				UserOne:   match.UserOne,
-				UserTwo:   match.UserTwo,
-				MatchedOn: match.MatchedOn,
-			})
+			mockMatchList = append(mockMatchList, match)
 		}
 	}
 
@@ -111,10 +105,10 @@ func (mc *mockComm) CheckUser(userID int64) (bool, error) {
 func makeRequest(env env, method string, url string, body string, authToken string) (*httptest.ResponseRecorder, error) {
 	rec := httptest.NewRecorder()
 	req, err := http.NewRequest(method, url, strings.NewReader(body))
-	req.Header.Set("Authorization", "Bearer "+authToken)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", "Bearer "+authToken)
 	env.router().ServeHTTP(rec, req)
 	return rec, nil
 }

--- a/user-db/init.sql
+++ b/user-db/init.sql
@@ -1,5 +1,5 @@
 CREATE TABLE user_temple (
-    id SERIAL PRIMARY KEY,
-    auth_id INT NOT NULL,
-    name TEXT
+  id SERIAL PRIMARY KEY,
+  auth_id INT NOT NULL,
+  name TEXT
 );

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -71,11 +71,10 @@ func (md *mockDAO) DeleteUser(input dao.DeleteUserInput) error {
 func makeRequest(env env, method string, url string, body string, authToken string) (*httptest.ResponseRecorder, error) {
 	rec := httptest.NewRecorder()
 	req, err := http.NewRequest(method, url, strings.NewReader(body))
-	req.Header.Set("Authorization", "Bearer "+authToken)
 	if err != nil {
 		return nil, err
 	}
-
+	req.Header.Set("Authorization", "Bearer "+authToken)
 	env.router().ServeHTTP(rec, req)
 	return rec, nil
 }


### PR DESCRIPTION
* Adds auth checks to endpoints
* Updates tests
  * Changes to populating mock datastore directly rather than with CREATE requests
  * Changes behaviour so that if you attempt to read a match not created by you, it will give an `Unauthorised` error rather than a `Not Found`, i.e. not revealing existence

Should probably add tests for trying to Updating another "creator's" match, but will leave for a later PR (will make a card on backlog).
