### PR TITLE
[auth] Use UUID for auth service

### DIFF
--- a/auth-db/init.sql
+++ b/auth-db/init.sql
@@ -1,5 +1,5 @@
 CREATE TABLE auth (
-    id SERIAL PRIMARY KEY,
+    id UUID PRIMARY KEY,
     email TEXT UNIQUE,
     password TEXT
 );

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TempleEight/spec-golang/auth/comm"
 	"github.com/TempleEight/spec-golang/auth/dao"
 	"github.com/dgrijalva/jwt-go"
+	"github.com/google/uuid"
 )
 
 type mockDAO struct {
@@ -27,16 +28,12 @@ func (md *mockDAO) CreateAuth(input dao.CreateAuthInput) (*dao.Auth, error) {
 	}
 
 	mockAuth := dao.Auth{
-		ID:       len(md.authList),
+		ID:       input.ID,
 		Email:    input.Email,
 		Password: input.Password,
 	}
 	md.authList = append(md.authList, mockAuth)
-	return &dao.Auth{
-		ID:       mockAuth.ID,
-		Email:    mockAuth.Email,
-		Password: mockAuth.Password,
-	}, nil
+	return &mockAuth, nil
 }
 
 func (md *mockDAO) ReadAuth(input dao.ReadAuthInput) (*dao.Auth, error) {
@@ -116,8 +113,9 @@ func TestCreateAuthHandlerSucceeds(t *testing.T) {
 		t.Fatalf("Claims doesn't contain an ID key")
 	}
 
-	if id.(string) != "0" {
-		t.Fatalf("ID is incorrect, found: %+v, wanted: 0", id)
+	_, err = uuid.Parse(id.(string))
+	if err != nil {
+		t.Fatalf("ID is not a valid UUID")
 	}
 
 	iss, ok := claims["iss"]
@@ -272,8 +270,9 @@ func TestReadAuthHandlerSucceeds(t *testing.T) {
 		t.Fatalf("Claims doesn't contain an ID key")
 	}
 
-	if id.(string) != "0" {
-		t.Fatalf("ID is incorrect, found: %+v, wanted: 0", id)
+	_, err = uuid.Parse(id.(string))
+	if err != nil {
+		t.Fatalf("ID is not a valid UUID")
 	}
 
 	iss, ok := claims["iss"]

--- a/auth/dao/dao.go
+++ b/auth/dao/dao.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/TempleEight/spec-golang/auth/utils"
+	"github.com/google/uuid"
+
 	// pq acts as the driver for SQL requests
 	"github.com/lib/pq"
 )
@@ -25,13 +27,14 @@ type DAO struct {
 
 // Auth encapsulates the object stored in the datastore
 type Auth struct {
-	ID       int
+	ID       uuid.UUID
 	Email    string
 	Password string
 }
 
 // CreateAuthInput encapsulates the information required to create a single auth in the datastore
 type CreateAuthInput struct {
+	ID       uuid.UUID
 	Email    string
 	Password string
 }
@@ -69,7 +72,7 @@ func executeQueryWithRowResponse(db *sql.DB, query string, args ...interface{}) 
 
 // CreateAuth creates a new auth in the datastore, returning the newly created auth
 func (dao *DAO) CreateAuth(input CreateAuthInput) (*Auth, error) {
-	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO auth (email, password) VALUES ($1, $2) RETURNING *", input.Email, input.Password)
+	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO auth (id, email, password) VALUES ($1, $2, $3) RETURNING *", input.ID, input.Email, input.Password)
 
 	var auth Auth
 	err := row.Scan(&auth.ID, &auth.Email, &auth.Password)

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
 	github.com/lib/pq v1.3.0
 	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d

--- a/auth/go.sum
+++ b/auth/go.sum
@@ -2,6 +2,8 @@ github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=


### PR DESCRIPTION
- Uses `UUID` instead of `int` for the `auth` service
- Closes #64 