### PR TITLE
[go-gen] Change IDs to UUIDs and update tests in Match service

### DIFF
--- a/match-db/init.sql
+++ b/match-db/init.sql
@@ -1,7 +1,7 @@
 CREATE TABLE match (
-  id SERIAL PRIMARY KEY,
-  auth_id INT NOT NULL,
-  userOne INT,
-  userTwo INT,
-  matchedOn TIMESTAMP,
+  id UUID PRIMARY KEY,
+  auth_id UUID NOT NULL,
+  userOne UUID,
+  userTwo UUID,
+  matchedOn TIMESTAMP
 );

--- a/match/comm/handler.go
+++ b/match/comm/handler.go
@@ -5,11 +5,12 @@ import (
 	"net/http"
 
 	"github.com/TempleEight/spec-golang/match/util"
+	"github.com/google/uuid"
 )
 
 // Comm provides the interface adopted by Handler, allowing for mocking
 type Comm interface {
-	CheckUser(userID int64) (bool, error)
+	CheckUser(userID uuid.UUID) (bool, error)
 }
 
 // Handler maintains the list of services and their associated hostnames
@@ -23,7 +24,7 @@ func Init(config *util.Config) *Handler {
 }
 
 // CheckUser makes a request to the target service to check if a user ID exists
-func (comm *Handler) CheckUser(userID int64) (bool, error) {
+func (comm *Handler) CheckUser(userID uuid.UUID) (bool, error) {
 	hostname, ok := comm.Services["user"]
 	if !ok {
 		return false, fmt.Errorf("service %s's hostname not in config file", "user")

--- a/match/dao/dao.go
+++ b/match/dao/dao.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/TempleEight/spec-golang/match/util"
+	"github.com/google/uuid"
+
 	// pq acts as the driver for SQL requests
 	_ "github.com/lib/pq"
 )
@@ -25,40 +27,41 @@ type DAO struct {
 
 // Match encapsulates the object stored in the datastore
 type Match struct {
-	ID        int64
-	AuthID    int64
-	UserOne   int64
-	UserTwo   int64
+	ID        uuid.UUID
+	AuthID    uuid.UUID
+	UserOne   uuid.UUID
+	UserTwo   uuid.UUID
 	MatchedOn string
 }
 
 // ListMatchInput encapsulates the information required to read a match list in the datastore
 type ListMatchInput struct {
-	AuthID int64
+	AuthID uuid.UUID
 }
 
 // CreateMatchInput encapsulates the information required to create a single match in the datastore
 type CreateMatchInput struct {
-	AuthID  int64
-	UserOne int64
-	UserTwo int64
+	ID      uuid.UUID
+	AuthID  uuid.UUID
+	UserOne uuid.UUID
+	UserTwo uuid.UUID
 }
 
 // ReadMatchInput encapsulates the information required to read a single match in the datastore
 type ReadMatchInput struct {
-	ID int64
+	ID uuid.UUID
 }
 
 // UpdateMatchInput encapsulates the information required to update a single match in the datastore
 type UpdateMatchInput struct {
-	ID      int64
-	UserOne int64
-	UserTwo int64
+	ID      uuid.UUID
+	UserOne uuid.UUID
+	UserTwo uuid.UUID
 }
 
 // DeleteMatchInput encapsulates the information required to delete a single match in the datastore
 type DeleteMatchInput struct {
-	ID int64
+	ID uuid.UUID
 }
 
 // Init opens the datastore connection, returning a DAO
@@ -139,7 +142,7 @@ func (dao *DAO) ReadMatch(input ReadMatchInput) (*Match, error) {
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
-			return nil, ErrMatchNotFound(input.ID)
+			return nil, ErrMatchNotFound(input.ID.String())
 		default:
 			return nil, err
 		}
@@ -157,7 +160,7 @@ func (dao *DAO) UpdateMatch(input UpdateMatchInput) (*Match, error) {
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
-			return nil, ErrMatchNotFound(input.ID)
+			return nil, ErrMatchNotFound(input.ID.String())
 		default:
 			return nil, err
 		}
@@ -172,7 +175,7 @@ func (dao *DAO) DeleteMatch(input DeleteMatchInput) error {
 	if err != nil {
 		return err
 	} else if rowsAffected == 0 {
-		return ErrMatchNotFound(input.ID)
+		return ErrMatchNotFound(input.ID.String())
 	}
 
 	return nil

--- a/match/dao/errors.go
+++ b/match/dao/errors.go
@@ -3,8 +3,8 @@ package dao
 import "fmt"
 
 // ErrMatchNotFound is returned when a match for the provided ID was not found
-type ErrMatchNotFound int64
+type ErrMatchNotFound string
 
 func (e ErrMatchNotFound) Error() string {
-	return fmt.Sprintf("match not found with ID %d", e)
+	return fmt.Sprintf("match not found with ID %d", string(e))
 }

--- a/match/go.mod
+++ b/match/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
 	github.com/lib/pq v1.3.0
 )

--- a/match/go.sum
+++ b/match/go.sum
@@ -2,6 +2,8 @@ github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=

--- a/match/match.go
+++ b/match/match.go
@@ -11,6 +11,7 @@ import (
 	"github.com/TempleEight/spec-golang/match/dao"
 	"github.com/TempleEight/spec-golang/match/util"
 	valid "github.com/asaskevich/govalidator"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
 
@@ -22,14 +23,14 @@ type env struct {
 
 // createMatchRequest contains the client-provided information required to create a single match
 type createMatchRequest struct {
-	UserOne *int64 `valid:"-"`
-	UserTwo *int64 `valid:"-"`
+	UserOne *uuid.UUID `valid:"-"`
+	UserTwo *uuid.UUID `valid:"-"`
 }
 
 // updateMatchRequest contains the client-provided information required to update a single match, excluding ID
 type updateMatchRequest struct {
-	UserOne *int64 `valid:"-"`
-	UserTwo *int64 `valid:"-"`
+	UserOne *uuid.UUID `valid:"-"`
+	UserTwo *uuid.UUID `valid:"-"`
 }
 
 // listMatchResponse contains a single match list to be returned to the client
@@ -39,25 +40,25 @@ type listMatchResponse struct {
 
 // createMatchResponse contains a newly created match to be returned to the client
 type createMatchResponse struct {
-	ID        int64
-	UserOne   int64
-	UserTwo   int64
+	ID        uuid.UUID
+	UserOne   uuid.UUID
+	UserTwo   uuid.UUID
 	MatchedOn string
 }
 
 // readMatchResponse contains a single match to be returned to the client
 type readMatchResponse struct {
-	ID        int64
-	UserOne   int64
-	UserTwo   int64
+	ID        uuid.UUID
+	UserOne   uuid.UUID
+	UserTwo   uuid.UUID
 	MatchedOn string
 }
 
 // updateMatchResponse contains a newly updated match to be returned to the client
 type updateMatchResponse struct {
-	ID        int64
-	UserOne   int64
-	UserTwo   int64
+	ID        uuid.UUID
+	UserOne   uuid.UUID
+	UserTwo   uuid.UUID
 	MatchedOn string
 }
 
@@ -105,7 +106,7 @@ func jsonMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func checkAuthorization(env *env, auth *util.Auth, matchID int64) (bool, error) {
+func checkAuthorization(env *env, auth *util.Auth, matchID uuid.UUID) (bool, error) {
 	match, err := env.dao.ReadMatch(dao.ReadMatchInput{
 		ID: matchID,
 	})
@@ -203,7 +204,15 @@ func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not create UUID: %s", err.Error()))
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
 	match, err := env.dao.CreateMatch(dao.CreateMatchInput{
+		ID:      uuid,
 		AuthID:  auth.ID,
 		UserOne: *req.UserOne,
 		UserTwo: *req.UserTwo,

--- a/match/util/util.go
+++ b/match/util/util.go
@@ -5,15 +5,15 @@ import (
 	"errors"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/google/uuid"
 )
 
 // Auth contains the unique identifier for a given auth
 type Auth struct {
-	ID int64
+	ID uuid.UUID
 }
 
 // GetConfig returns a configuration object from decoding the given configuration file
@@ -42,19 +42,14 @@ func CreateErrorJSON(message string) string {
 	return string(json)
 }
 
-// ExtractIDFromRequest extracts the parameter provided under parameter ID and converts it into an integer
-func ExtractIDFromRequest(requestParams map[string]string) (int64, error) {
-	idStr := requestParams["id"]
-	if len(idStr) == 0 {
-		return 0, errors.New("No ID provided")
+// ExtractIDFromRequest extracts the parameter provided under parameter ID and converts it into a UUID
+func ExtractIDFromRequest(requestParams map[string]string) (uuid.UUID, error) {
+	id := requestParams["id"]
+	if len(id) == 0 {
+		return uuid.Nil, errors.New("No ID provided")
 	}
 
-	id, err := strconv.ParseInt(idStr, 10, 64)
-	if err != nil {
-		return 0, errors.New("Invalid ID provided")
-	}
-
-	return id, nil
+	return uuid.Parse(id)
 }
 
 // ExtractAuthIDFromRequest extracts a token from a header of the form `Authorization: Bearer <token>`
@@ -84,11 +79,11 @@ func ExtractAuthIDFromRequest(headers http.Header) (*Auth, error) {
 		return nil, errors.New("JWT does not contain an id")
 	}
 
-	// Convert to an integer
-	intID, err := id.(json.Number).Int64()
+	// Convert to a UUID
+	uuid, err := uuid.Parse(id.(string))
 	if err != nil {
 		return nil, err
 	}
 
-	return &Auth{intID}, nil
+	return &Auth{uuid}, nil
 }


### PR DESCRIPTION
* Switches out `int64` for `uuid.UUID`
* Updates tests