### PR TITLE
[match] Use RFC3339/ISO8601 for time formatting throughout

### DIFF
--- a/match-db/init.sql
+++ b/match-db/init.sql
@@ -3,5 +3,5 @@ CREATE TABLE match (
   auth_id UUID NOT NULL,
   userOne UUID,
   userTwo UUID,
-  matchedOn TIMESTAMP WITH TIME ZONE
+  matchedOn TIMESTAMPTZ
 );

--- a/match-db/init.sql
+++ b/match-db/init.sql
@@ -3,5 +3,5 @@ CREATE TABLE match (
   auth_id UUID NOT NULL,
   userOne UUID,
   userTwo UUID,
-  matchedOn TIMESTAMP
+  matchedOn TIMESTAMP WITH TIME ZONE
 );

--- a/match/comm/handler.go
+++ b/match/comm/handler.go
@@ -10,7 +10,7 @@ import (
 
 // Comm provides the interface adopted by Handler, allowing for mocking
 type Comm interface {
-	CheckUser(userID uuid.UUID) (bool, error)
+	CheckUser(userID uuid.UUID, token string) (bool, error)
 }
 
 // Handler maintains the list of services and their associated hostnames
@@ -24,13 +24,20 @@ func Init(config *util.Config) *Handler {
 }
 
 // CheckUser makes a request to the target service to check if a user ID exists
-func (comm *Handler) CheckUser(userID uuid.UUID) (bool, error) {
+func (comm *Handler) CheckUser(userID uuid.UUID, token string) (bool, error) {
 	hostname, ok := comm.Services["user"]
 	if !ok {
 		return false, fmt.Errorf("service %s's hostname not in config file", "user")
 	}
 
-	resp, err := http.Get(fmt.Sprintf("%s/%d", hostname, userID))
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", hostname, userID.String()), nil)
+	if err != nil {
+		return false, err
+	}
+
+	// Token should already be in the form `Bearer <token>`
+	req.Header.Set("Authorization", token)
+	resp, err := new(http.Client).Do(req)
 	if err != nil {
 		return false, err
 	}

--- a/match/dao/dao.go
+++ b/match/dao/dao.go
@@ -123,7 +123,7 @@ func (dao *DAO) ListMatch(input ListMatchInput) (*[]Match, error) {
 
 // CreateMatch creates a new match in the datastore, returning the newly created match
 func (dao *DAO) CreateMatch(input CreateMatchInput) (*Match, error) {
-	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO match (auth_id, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, NOW()) RETURNING *", input.AuthID, input.UserOne, input.UserTwo)
+	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO match (id, auth_id, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, NOW()) RETURNING *", input.ID, input.AuthID, input.UserOne, input.UserTwo)
 
 	var match Match
 	err := row.Scan(&match.ID, &match.AuthID, &match.UserOne, &match.UserTwo, &match.MatchedOn)

--- a/match/dao/dao.go
+++ b/match/dao/dao.go
@@ -3,6 +3,7 @@ package dao
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/TempleEight/spec-golang/match/util"
 	"github.com/google/uuid"
@@ -31,7 +32,7 @@ type Match struct {
 	AuthID    uuid.UUID
 	UserOne   uuid.UUID
 	UserTwo   uuid.UUID
-	MatchedOn string
+	MatchedOn time.Time
 }
 
 // ListMatchInput encapsulates the information required to read a match list in the datastore

--- a/match/match.go
+++ b/match/match.go
@@ -179,7 +179,7 @@ func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userOneValid, err := env.comm.CheckUser(*req.UserOne)
+	userOneValid, err := env.comm.CheckUser(*req.UserOne, r.Header.Get("Authorization"))
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Unable to reach user service: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -187,12 +187,12 @@ func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !userOneValid {
-		errMsg := util.CreateErrorJSON(fmt.Sprintf("Unknown User: %d", *req.UserOne))
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Unknown User: %s", req.UserOne.String()))
 		http.Error(w, errMsg, http.StatusBadRequest)
 		return
 	}
 
-	userTwoValid, err := env.comm.CheckUser(*req.UserTwo)
+	userTwoValid, err := env.comm.CheckUser(*req.UserTwo, r.Header.Get("Authorization"))
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Unable to reach user service: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -200,7 +200,7 @@ func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !userTwoValid {
-		errMsg := util.CreateErrorJSON(fmt.Sprintf("Unknown User: %d", *req.UserTwo))
+		errMsg := util.CreateErrorJSON(fmt.Sprintf("Unknown User: %s", req.UserTwo.String()))
 		http.Error(w, errMsg, http.StatusBadRequest)
 		return
 	}
@@ -340,7 +340,7 @@ func (env *env) updateMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userOneValid, err := env.comm.CheckUser(*req.UserOne)
+	userOneValid, err := env.comm.CheckUser(*req.UserOne, r.Header.Get("Authorization"))
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Unable to reach %s service: %s", "user", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -353,7 +353,7 @@ func (env *env) updateMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userTwoValid, err := env.comm.CheckUser(*req.UserTwo)
+	userTwoValid, err := env.comm.CheckUser(*req.UserTwo, r.Header.Get("Authorization"))
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Unable to reach %s service: %s", "user", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)

--- a/match/match.go
+++ b/match/match.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/TempleEight/spec-golang/match/comm"
 	"github.com/TempleEight/spec-golang/match/dao"
@@ -142,7 +143,7 @@ func (env *env) listMatchHandler(w http.ResponseWriter, r *http.Request) {
 			ID:        match.ID,
 			UserOne:   match.UserOne,
 			UserTwo:   match.UserTwo,
-			MatchedOn: match.MatchedOn,
+			MatchedOn: match.MatchedOn.Format(time.RFC3339),
 		})
 	}
 
@@ -227,7 +228,7 @@ func (env *env) createMatchHandler(w http.ResponseWriter, r *http.Request) {
 		ID:        match.ID,
 		UserOne:   match.UserOne,
 		UserTwo:   match.UserTwo,
-		MatchedOn: match.MatchedOn,
+		MatchedOn: match.MatchedOn.Format(time.RFC3339),
 	})
 }
 
@@ -282,7 +283,7 @@ func (env *env) readMatchHandler(w http.ResponseWriter, r *http.Request) {
 		ID:        match.ID,
 		UserOne:   match.UserOne,
 		UserTwo:   match.UserTwo,
-		MatchedOn: match.MatchedOn,
+		MatchedOn: match.MatchedOn.Format(time.RFC3339),
 	})
 }
 
@@ -385,7 +386,7 @@ func (env *env) updateMatchHandler(w http.ResponseWriter, r *http.Request) {
 		ID:        match.ID,
 		UserOne:   match.UserOne,
 		UserTwo:   match.UserTwo,
-		MatchedOn: match.MatchedOn,
+		MatchedOn: match.MatchedOn.Format(time.RFC3339),
 	})
 }
 

--- a/match/match_test.go
+++ b/match/match_test.go
@@ -117,7 +117,7 @@ func (md *mockDAO) DeleteMatch(input dao.DeleteMatchInput) error {
 	return dao.ErrMatchNotFound(input.ID.String())
 }
 
-func (mc *mockComm) CheckUser(userID uuid.UUID) (bool, error) {
+func (mc *mockComm) CheckUser(userID uuid.UUID, token string) (bool, error) {
 	for _, id := range mc.userIDs {
 		if id == userID {
 			return true, nil


### PR DESCRIPTION
Retrieve time from Postgres as Go's `time.Time` type, then use ISO8601 encoding for JSON responses.

Had to make some tweaks (also in #73, so let's merge this one first) to make the existing code actually run. 

Since we don't have any integration tests I've performed manual testing:

```
ACCESS1=$(curl -s -X POST localhost:8000/api/auth -d '{"email":"jay1@test.com", "password":"abcdefgh"}' | jq -r .AccessToken)
ACCESS2=$(curl -s -X POST localhost:8000/api/auth -d '{"email":"jay2@test.com", "password":"abcdefgh"}' | jq -r .AccessToken)

USER1=$(curl -s -X POST localhost:8000/api/user -d '{"name": "Jay"}' -H "Authorization: Bearer $ACCESS1" | jq -r .ID)
USER2=$(curl -s -X POST localhost:8000/api/user -d '{"name": "Lewis"}' -H "Authorization: Bearer $ACCESS2" | jq -r .ID)

curl -X POST localhost:8000/api/match -d "{\"UserOne\": \"$USER1\", \"UserTwo\": \"$USER2\"}" -H "Authorization: Bearer $ACCESS1"
```