### PR TITLE
[go-gen] Rename auth_id to created_by in datastore

### DIFF
--- a/match-db/init.sql
+++ b/match-db/init.sql
@@ -1,6 +1,6 @@
 CREATE TABLE match (
   id UUID PRIMARY KEY,
-  auth_id UUID NOT NULL,
+  created_by UUID NOT NULL,
   userOne UUID,
   userTwo UUID,
   matchedOn TIMESTAMPTZ

--- a/match/dao/dao.go
+++ b/match/dao/dao.go
@@ -29,7 +29,7 @@ type DAO struct {
 // Match encapsulates the object stored in the datastore
 type Match struct {
 	ID        uuid.UUID
-	AuthID    uuid.UUID
+	CreatedBy uuid.UUID
 	UserOne   uuid.UUID
 	UserTwo   uuid.UUID
 	MatchedOn time.Time
@@ -98,7 +98,7 @@ func executeQueryWithRowResponses(db *sql.DB, query string, args ...interface{})
 
 // ListMatch returns a list containing every match in the datastore for a given ID
 func (dao *DAO) ListMatch(input ListMatchInput) (*[]Match, error) {
-	rows, err := executeQueryWithRowResponses(dao.DB, "SELECT * FROM match WHERE auth_id = $1", input.AuthID)
+	rows, err := executeQueryWithRowResponses(dao.DB, "SELECT * FROM match WHERE created_by = $1", input.AuthID)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (dao *DAO) ListMatch(input ListMatchInput) (*[]Match, error) {
 	matchList := make([]Match, 0)
 	for rows.Next() {
 		var match Match
-		err = rows.Scan(&match.ID, &match.AuthID, &match.UserOne, &match.UserTwo, &match.MatchedOn)
+		err = rows.Scan(&match.ID, &match.CreatedBy, &match.UserOne, &match.UserTwo, &match.MatchedOn)
 		if err != nil {
 			return nil, err
 		}
@@ -123,10 +123,10 @@ func (dao *DAO) ListMatch(input ListMatchInput) (*[]Match, error) {
 
 // CreateMatch creates a new match in the datastore, returning the newly created match
 func (dao *DAO) CreateMatch(input CreateMatchInput) (*Match, error) {
-	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO match (id, auth_id, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, NOW()) RETURNING *", input.ID, input.AuthID, input.UserOne, input.UserTwo)
+	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO match (id, created_by, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, NOW()) RETURNING *", input.ID, input.AuthID, input.UserOne, input.UserTwo)
 
 	var match Match
-	err := row.Scan(&match.ID, &match.AuthID, &match.UserOne, &match.UserTwo, &match.MatchedOn)
+	err := row.Scan(&match.ID, &match.CreatedBy, &match.UserOne, &match.UserTwo, &match.MatchedOn)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func (dao *DAO) ReadMatch(input ReadMatchInput) (*Match, error) {
 	row := executeQueryWithRowResponse(dao.DB, "SELECT * FROM match WHERE id = $1", input.ID)
 
 	var match Match
-	err := row.Scan(&match.ID, &match.AuthID, &match.UserOne, &match.UserTwo, &match.MatchedOn)
+	err := row.Scan(&match.ID, &match.CreatedBy, &match.UserOne, &match.UserTwo, &match.MatchedOn)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
@@ -157,7 +157,7 @@ func (dao *DAO) UpdateMatch(input UpdateMatchInput) (*Match, error) {
 	row := executeQueryWithRowResponse(dao.DB, "UPDATE match SET userOne = $1, userTwo = $2, matchedOn = NOW() WHERE id = $3 RETURNING *", input.UserOne, input.UserTwo, input.ID)
 
 	var match Match
-	err := row.Scan(&match.ID, &match.AuthID, &match.UserOne, &match.UserTwo, &match.MatchedOn)
+	err := row.Scan(&match.ID, &match.CreatedBy, &match.UserOne, &match.UserTwo, &match.MatchedOn)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/match/match.go
+++ b/match/match.go
@@ -107,7 +107,7 @@ func jsonMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func checkAuthorization(env *env, auth *util.Auth, matchID uuid.UUID) (bool, error) {
+func checkAuthorization(env *env, matchID uuid.UUID, auth *util.Auth) (bool, error) {
 	match, err := env.dao.ReadMatch(dao.ReadMatchInput{
 		ID: matchID,
 	})
@@ -115,7 +115,7 @@ func checkAuthorization(env *env, auth *util.Auth, matchID uuid.UUID) (bool, err
 		return false, err
 	}
 
-	return match.AuthID == auth.ID, nil
+	return match.CreatedBy == auth.ID, nil
 }
 
 func (env *env) listMatchHandler(w http.ResponseWriter, r *http.Request) {
@@ -246,7 +246,7 @@ func (env *env) readMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authorized, err := checkAuthorization(env, auth, matchID)
+	authorized, err := checkAuthorization(env, matchID, auth)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrMatchNotFound:
@@ -301,7 +301,7 @@ func (env *env) updateMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authorized, err := checkAuthorization(env, auth, matchID)
+	authorized, err := checkAuthorization(env, matchID, auth)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrMatchNotFound:
@@ -404,7 +404,7 @@ func (env *env) deleteMatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authorized, err := checkAuthorization(env, auth, matchID)
+	authorized, err := checkAuthorization(env, matchID, auth)
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrMatchNotFound:

--- a/match/match_it_test.go
+++ b/match/match_it_test.go
@@ -1,3 +1,5 @@
+// +build it
+
 package main
 
 import (

--- a/match/match_test.go
+++ b/match/match_test.go
@@ -44,7 +44,7 @@ type mockComm struct {
 func (md *mockDAO) ListMatch(input dao.ListMatchInput) (*[]dao.Match, error) {
 	mockMatchList := make([]dao.Match, 0)
 	for _, match := range md.matchList {
-		if match.AuthID == input.AuthID {
+		if match.CreatedBy == input.AuthID {
 			mockMatchList = append(mockMatchList, match)
 		}
 	}
@@ -60,7 +60,7 @@ func (md *mockDAO) CreateMatch(input dao.CreateMatchInput) (*dao.Match, error) {
 
 	mockMatch := dao.Match{
 		ID:        uuid.MustParse(matchUUID0),
-		AuthID:    input.AuthID,
+		CreatedBy: input.AuthID,
 		UserOne:   input.UserOne,
 		UserTwo:   input.UserTwo,
 		MatchedOn: time,
@@ -68,7 +68,7 @@ func (md *mockDAO) CreateMatch(input dao.CreateMatchInput) (*dao.Match, error) {
 	md.matchList = append(md.matchList, mockMatch)
 	return &dao.Match{
 		ID:        mockMatch.ID,
-		AuthID:    mockMatch.AuthID,
+		CreatedBy: mockMatch.CreatedBy,
 		UserOne:   mockMatch.UserOne,
 		UserTwo:   mockMatch.UserTwo,
 		MatchedOn: mockMatch.MatchedOn,
@@ -97,7 +97,7 @@ func (md *mockDAO) UpdateMatch(input dao.UpdateMatchInput) (*dao.Match, error) {
 			md.matchList[i].MatchedOn = time
 			return &dao.Match{
 				ID:        md.matchList[i].ID,
-				AuthID:    md.matchList[i].AuthID,
+				CreatedBy: md.matchList[i].CreatedBy,
 				UserOne:   md.matchList[i].UserOne,
 				UserTwo:   md.matchList[i].UserTwo,
 				MatchedOn: md.matchList[i].MatchedOn,
@@ -148,21 +148,21 @@ func TestListMatchHandlerSucceeds(t *testing.T) {
 	matchList := []dao.Match{
 		dao.Match{
 			ID:        uuid.MustParse(matchUUID0),
-			AuthID:    uuid.MustParse(UUID0),
+			CreatedBy: uuid.MustParse(UUID0),
 			UserOne:   uuid.MustParse(userUUID0),
 			UserTwo:   uuid.MustParse(userUUID1),
 			MatchedOn: time,
 		},
 		dao.Match{
 			ID:        uuid.MustParse(matchUUID1),
-			AuthID:    uuid.MustParse(UUID0),
+			CreatedBy: uuid.MustParse(UUID0),
 			UserOne:   uuid.MustParse(userUUID0),
 			UserTwo:   uuid.MustParse(userUUID2),
 			MatchedOn: time,
 		},
 		dao.Match{
 			ID:        uuid.MustParse(matchUUID2),
-			AuthID:    uuid.MustParse(UUID1),
+			CreatedBy: uuid.MustParse(UUID1),
 			UserOne:   uuid.MustParse(userUUID1),
 			UserTwo:   uuid.MustParse(userUUID2),
 			MatchedOn: time,
@@ -357,7 +357,7 @@ func TestReadMatchHandlerSucceeds(t *testing.T) {
 	// Populate mock datastore
 	matchList := []dao.Match{dao.Match{
 		ID:        uuid.MustParse(matchUUID0),
-		AuthID:    uuid.MustParse(UUID0),
+		CreatedBy: uuid.MustParse(UUID0),
 		UserOne:   uuid.MustParse(userUUID0),
 		UserTwo:   uuid.MustParse(userUUID1),
 		MatchedOn: time,
@@ -440,7 +440,7 @@ func TestUpdateUserHandlerSucceeds(t *testing.T) {
 	// Populate mock datastore
 	matchList := []dao.Match{dao.Match{
 		ID:        uuid.MustParse(matchUUID0),
-		AuthID:    uuid.MustParse(UUID0),
+		CreatedBy: uuid.MustParse(UUID0),
 		UserOne:   uuid.MustParse(userUUID0),
 		UserTwo:   uuid.MustParse(userUUID1),
 		MatchedOn: time,
@@ -503,7 +503,7 @@ func TestUpdateMatchHandlerFailsOnMalformedJSONBody(t *testing.T) {
 	// Populate mock datastore
 	matchList := []dao.Match{dao.Match{
 		ID:        uuid.MustParse(matchUUID0),
-		AuthID:    uuid.MustParse(UUID0),
+		CreatedBy: uuid.MustParse(UUID0),
 		UserOne:   uuid.MustParse(userUUID0),
 		UserTwo:   uuid.MustParse(userUUID1),
 		MatchedOn: time,
@@ -537,7 +537,7 @@ func TestUpdateMatchHandlerFailsOnNoBody(t *testing.T) {
 	// Populate mock datastore
 	matchList := []dao.Match{dao.Match{
 		ID:        uuid.MustParse(matchUUID0),
-		AuthID:    uuid.MustParse(UUID0),
+		CreatedBy: uuid.MustParse(UUID0),
 		UserOne:   uuid.MustParse(userUUID0),
 		UserTwo:   uuid.MustParse(userUUID1),
 		MatchedOn: time,
@@ -614,7 +614,7 @@ func TestUpdateMatchHandlerFailsOnInvalidUserOne(t *testing.T) {
 	// Populate mock datastore
 	matchList := []dao.Match{dao.Match{
 		ID:        uuid.MustParse(matchUUID0),
-		AuthID:    uuid.MustParse(UUID0),
+		CreatedBy: uuid.MustParse(UUID0),
 		UserOne:   uuid.MustParse(userUUID0),
 		UserTwo:   uuid.MustParse(userUUID1),
 		MatchedOn: time,
@@ -649,7 +649,7 @@ func TestUpdateMatchHandlerFailsOnInvalidUserTwo(t *testing.T) {
 	// Populate mock datastore
 	matchList := []dao.Match{dao.Match{
 		ID:        uuid.MustParse(matchUUID0),
-		AuthID:    uuid.MustParse(UUID0),
+		CreatedBy: uuid.MustParse(UUID0),
 		UserOne:   uuid.MustParse(userUUID0),
 		UserTwo:   uuid.MustParse(userUUID1),
 		MatchedOn: time,
@@ -685,7 +685,7 @@ func TestUpdateMatchHandlerFailsOnAllInvalidReferences(t *testing.T) {
 	// Populate mock datastore
 	matchList := []dao.Match{dao.Match{
 		ID:        uuid.MustParse(matchUUID0),
-		AuthID:    uuid.MustParse(UUID0),
+		CreatedBy: uuid.MustParse(UUID0),
 		UserOne:   uuid.MustParse(userUUID0),
 		UserTwo:   uuid.MustParse(userUUID1),
 		MatchedOn: time,
@@ -721,7 +721,7 @@ func TestDeleteMatchHandlerSucceeds(t *testing.T) {
 	// Populate mock datastore
 	matchList := []dao.Match{dao.Match{
 		ID:        uuid.MustParse(matchUUID0),
-		AuthID:    uuid.MustParse(UUID0),
+		CreatedBy: uuid.MustParse(UUID0),
 		UserOne:   uuid.MustParse(userUUID0),
 		UserTwo:   uuid.MustParse(userUUID1),
 		MatchedOn: time,


### PR DESCRIPTION
* Renames auth_id to created_by in the datastore
  * Inputs to DAO remain `AuthID` so they make semantic sense