### PR TITLE
[user][hook] Add hook for create endpoint

### DIFF
--- a/user/hook.go
+++ b/user/hook.go
@@ -1,0 +1,30 @@
+package main
+
+import "github.com/TempleEight/spec-golang/user/dao"
+
+// Hook allows additional code to be executed before and after every datastore interaction
+// Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
+type Hook struct {
+	beforeCreateHooks []*func(env *env, req createUserRequest, input *dao.CreateUserInput) *HookError
+	afterCreateHooks  []*func(env *env, user *dao.User) *HookError
+}
+
+// HookError wraps an existing error with HTTP status code
+type HookError struct {
+	statusCode int
+	error      error
+}
+
+func (e *HookError) Error() string {
+	return e.error.Error()
+}
+
+// BeforeCreate adds a new hook to be executed before creating the object in the datastore
+func (h *Hook) BeforeCreate(hook func(env *env, req createUserRequest, input *dao.CreateUserInput) *HookError) {
+	h.beforeCreateHooks = append(h.beforeCreateHooks, &hook)
+}
+
+// AfterCreate adds a new hook to be executed after creating the object in the datastore
+func (h *Hook) AfterCreate(hook func(env *env, user *dao.User) *HookError) {
+	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
+}

--- a/user/setup.go
+++ b/user/setup.go
@@ -1,0 +1,5 @@
+package main
+
+func (env *env) setup() {
+	// Add user defined code here
+}

--- a/user/user.go
+++ b/user/user.go
@@ -16,7 +16,7 @@ import (
 
 // env defines the environment that requests should be executed within
 type env struct {
-	dao dao.Datastore
+	dao  dao.Datastore
 	hook Hook
 }
 
@@ -119,7 +119,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		Name: req.Name,
 	}
 
-	for _, hook := range env.hook.beforeCreateHooks{
+	for _, hook := range env.hook.beforeCreateHooks {
 		err := (*hook)(env, req, &input)
 		if err != nil {
 			errMsg := util.CreateErrorJSON(err.Error())
@@ -135,7 +135,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterCreateHooks{
+	for _, hook := range env.hook.afterCreateHooks {
 		err := (*hook)(env, user)
 		if err != nil {
 			errMsg := util.CreateErrorJSON(err.Error())

--- a/user/user_it_test.go
+++ b/user/user_it_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	environment = env{d}
+	environment = env{d, Hook{}}
 
 	os.Exit(m.Run())
 }

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -81,6 +81,7 @@ func makeRequest(env env, method string, url string, body string, authToken stri
 func makeMockEnv() env {
 	return env{
 		&mockDAO{userList: make([]dao.User, 0)},
+		Hook{},
 	}
 }
 


### PR DESCRIPTION
The first prototype of adding additional logic via hooks. I've left the implementation empty, but an example of how it could be used is below.

For now, the **before** calls takes the env (to allow for more logging and metrics later on), a **value** type of the request and **reference** type of the dao input. The request type is not a pointer, since any changes to this object will not be used anywhere, so we can implicitly indicate that through the type - however we still want access to it for any `@client` attributes.

The DAO type can be modified and this will change what's stored in the datastore, so this is a pointer - this can be used for setting `@serverSet` attributes

Please look at the filenames / type names and let me know what you think. Definitely aware these will probably change as we want to add more functionality, but I think it's a good starting point.

Example Hooks:
``` go
package main

import (
	"errors"
	"log"
	"net/http"

	"github.com/TempleEight/spec-golang/user/dao"
)

func (env *env) setup() {
	env.hook.beforeCreate(beforeCreateHook)
	env.hook.afterCreate(afterCreateHook)
}

func beforeCreateHook(env *env, req createUserRequest, input *dao.CreateUserInput) *HookError {
	if req.Name == "Lewis" {
		return &HookError{http.StatusTeapot, errors.New("we do not allow users called Lewis")}
	}
        // All users are now named Corona
	input.Name = "Corona"
	return nil
}

func afterCreateHook(env *env, user *dao.User) *HookError {
	log.Printf("Added a user with ID: %s", user.ID)
	return nil
}
```