### PR TITLE
[user][hooks] Allow router configuration

### DIFF
--- a/user/setup.go
+++ b/user/setup.go
@@ -1,5 +1,7 @@
 package main
 
-func (env *env) setup() {
+import "github.com/gorilla/mux"
+
+func (env *env) setup(router *mux.Router) {
 	// Add user defined code here
 }

--- a/user/user.go
+++ b/user/user.go
@@ -49,7 +49,7 @@ type updateUserResponse struct {
 }
 
 // router generates a router for this service
-func (env *env) router() *mux.Router {
+func defaultRouter(env *env) *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/user", env.createUserHandler).Methods(http.MethodPost)
 	r.HandleFunc("/user/{id}", env.readUserHandler).Methods(http.MethodGet)
@@ -78,9 +78,10 @@ func main() {
 	env := env{d, Hook{}}
 
 	// Call into non-generated entry-point
-	env.setup()
+	router := defaultRouter(&env)
+	env.setup(router)
 
-	log.Fatal(http.ListenAndServe(":80", env.router()))
+	log.Fatal(http.ListenAndServe(":80", router))
 }
 
 func jsonMiddleware(next http.Handler) http.Handler {


### PR DESCRIPTION
By taking the router as an argument to set up, the user can define their own additional endpoints:

```go
func (env *env) setup(router *mux.Router) {
    router.HandleFunc("/yeet", env.yeetHandler).Methods(http.MethodGet)
}
```

Unfortunately the router doesn't let you delete existing endpoints, so to accomplish this you'd have to create a new router and add only the endpoints you want using my *favourite* `go` syntax...

```go
func (env *env) setup(router *mux.Router) {
    *router = *mux.NewRouter()
    router.HandleFunc("/yeet", env.readUserHandler).Methods(http.MethodGet)
}
```