### PR TITLE
[hooks] Extend datastore type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ language: go
 
 script: 
 # Run unit and integration tests
-- for svc in user auth match; do cd $svc && docker-compose up --build $svc && cd ..; done
+- cd user && docker-compose up --build user && cd ..; done
+- cd auth && docker-compose up --build auth && cd ..; done
+- cd match && docker-compose up --build match && cd ..; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ language: go
 
 script: 
 # Run unit and integration tests
-- cd user && docker-compose up --build user && cd ..; done
-- cd auth && docker-compose up --build auth && cd ..; done
-- cd match && docker-compose up --build match && cd ..; done
+- cd user && docker-compose up --build user && cd ..
+- cd auth && docker-compose up --build auth && cd ..
+- cd match && docker-compose up --build match && cd ..

--- a/auth/dao/dao.go
+++ b/auth/dao/dao.go
@@ -14,8 +14,8 @@ import (
 // https://www.postgresql.org/docs/9.3/errcodes-appendix.html
 const psqlUniqueViolation = "unique_violation"
 
-// Datastore provides the interface adopted by the DAO, allowing for mocking
-type Datastore interface {
+// BaseDatastore provides the basic datastore methods
+type BaseDatastore interface {
 	CreateAuth(input CreateAuthInput) (*Auth, error)
 	ReadAuth(input ReadAuthInput) (*Auth, error)
 }

--- a/auth/dao/datastore.go
+++ b/auth/dao/datastore.go
@@ -1,0 +1,6 @@
+package dao
+
+// Datastore provides the interface adopted by the DAO, allowing for mocking
+type Datastore interface {
+	BaseDatastore
+}

--- a/match/dao/dao.go
+++ b/match/dao/dao.go
@@ -12,8 +12,8 @@ import (
 	_ "github.com/lib/pq"
 )
 
-// Datastore provides the interface adopted by the DAO, allowing for mocking
-type Datastore interface {
+// BaseDatastore provides the basic datastore methods
+type BaseDatastore interface {
 	ListMatch(input ListMatchInput) (*[]Match, error)
 	CreateMatch(input CreateMatchInput) (*Match, error)
 	ReadMatch(input ReadMatchInput) (*Match, error)

--- a/match/dao/datastore.go
+++ b/match/dao/datastore.go
@@ -1,0 +1,6 @@
+package dao
+
+// Datastore provides the interface adopted by the DAO, allowing for mocking
+type Datastore interface {
+	BaseDatastore
+}

--- a/user/dao/dao.go
+++ b/user/dao/dao.go
@@ -10,8 +10,8 @@ import (
 	_ "github.com/lib/pq"
 )
 
-// Datastore provides the interface adopted by the DAO, allowing for mocking
-type Datastore interface {
+// BaseDatastore provides the basic datastore methods
+type BaseDatastore interface {
 	CreateUser(input CreateUserInput) (*User, error)
 	ReadUser(input ReadUserInput) (*User, error)
 	UpdateUser(input UpdateUserInput) (*User, error)

--- a/user/dao/datastore.go
+++ b/user/dao/datastore.go
@@ -1,0 +1,6 @@
+package dao
+
+// Datastore provides the interface adopted by the DAO, allowing for mocking
+type Datastore interface {
+	BaseDatastore
+}

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -74,7 +74,7 @@ func makeRequest(env env, method string, url string, body string, authToken stri
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+authToken)
-	env.router().ServeHTTP(rec, req)
+	defaultRouter(&env).ServeHTTP(rec, req)
 	return rec, nil
 }
 


### PR DESCRIPTION
- Add a new DAO type in every service that extends the generated interface
- Fix the CI, since it would exit with the status code of the last loop iteration, instead of early returning 