### PR TITLE
[metrics][user] Add custom metrics to the user service

### DIFF
--- a/grafana/provisioning/dashboards/user.json
+++ b/grafana/provisioning/dashboards/user.json
@@ -15,7 +15,7 @@
     "editable": true,
     "gnetId": null,
     "graphTooltip": 0,
-    "id": null,
+    "id": 2,
     "links": [],
     "panels": [
         {
@@ -27,7 +27,7 @@
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
-                "h": 9,
+                "h": 6,
                 "w": 12,
                 "x": 0,
                 "y": 0
@@ -35,10 +35,13 @@
             "hiddenSeries": false,
             "id": 2,
             "legend": {
+                "alignAsTable": false,
                 "avg": false,
                 "current": false,
+                "hideEmpty": false,
                 "max": false,
                 "min": false,
+                "rightSide": true,
                 "show": true,
                 "total": false,
                 "values": false
@@ -59,15 +62,22 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "promhttp_metric_handler_requests_total{job=\"user\"}",
+                    "expr": "rate(user_request_success_total{request_type=\"create\"}[5m])",
+                    "legendFormat": "Success",
                     "refId": "A"
+                },
+                {
+                    "expr": "rate(user_request_failure_total{request_type=\"create\"}[5m])",
+                    "format": "time_series",
+                    "legendFormat": "{{error_code}}",
+                    "refId": "B"
                 }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Panel Title",
+            "title": "Create User Requests",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -84,7 +94,295 @@
             "yaxes": [
                 {
                     "format": "short",
+                    "label": "QPS",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
                     "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 0
+            },
+            "hiddenSeries": false,
+            "id": 3,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "rate(user_request_success_total{request_type=\"read\"}[5m])",
+                    "legendFormat": "Success",
+                    "refId": "A"
+                },
+                {
+                    "expr": "rate(user_request_failure_total{request_type=\"read\"}[5m])",
+                    "format": "time_series",
+                    "legendFormat": "{{error_code}}",
+                    "refId": "B"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Read User Requests",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": "QPS",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 6
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "rate(user_request_success_total{request_type=\"update\"}[5m])",
+                    "legendFormat": "Success",
+                    "refId": "A"
+                },
+                {
+                    "expr": "rate(user_request_failure_total{request_type=\"update\"}[5m])",
+                    "format": "time_series",
+                    "legendFormat": "{{error_code}}",
+                    "refId": "B"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Update User Requests",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": "QPS",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 6
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "rate(user_request_success_total{request_type=\"delete\"}[5m])",
+                    "legendFormat": "Success",
+                    "refId": "A"
+                },
+                {
+                    "expr": "rate(user_request_failure_total{request_type=\"delete\"}[5m])",
+                    "format": "time_series",
+                    "legendFormat": "{{error_code}}",
+                    "refId": "B"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Delete User Requests",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": "QPS",
                     "logBase": 1,
                     "max": null,
                     "min": null,
@@ -105,6 +403,7 @@
             }
         }
     ],
+    "refresh": "5s",
     "schemaVersion": 22,
     "style": "dark",
     "tags": [],
@@ -112,7 +411,7 @@
         "list": []
     },
     "time": {
-        "from": "now-6h",
+        "from": "now-15m",
         "to": "now"
     },
     "timepicker": {
@@ -130,7 +429,7 @@
         ]
     },
     "timezone": "",
-    "title": "New dashboard",
-    "uid": null,
-    "version": 0
+    "title": "User Dashboard",
+    "uid": "2HpG6wuWz",
+    "version": 1
 }

--- a/user/metric/metric.go
+++ b/user/metric/metric.go
@@ -1,4 +1,4 @@
-package main
+package metric
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
@@ -6,17 +6,17 @@ import (
 )
 
 var (
-	requestCreate = "create"
-	requestRead   = "read"
-	requestUpdate = "update"
-	requestDelete = "delete"
+	RequestCreate = "create"
+	RequestRead   = "read"
+	RequestUpdate = "update"
+	RequestDelete = "delete"
 
-	requestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "user_request_success_total",
 		Help: "The total number of successful requests",
 	}, []string{"request_type"})
 
-	requestFailure = promauto.NewCounterVec(prometheus.CounterOpts{
+	RequestFailure = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "user_request_failure_total",
 		Help: "The total number of failed requests",
 	}, []string{"request_type", "error_code"})

--- a/user/metrics.go
+++ b/user/metrics.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	requestCreate = "create"
+	requestRead   = "read"
+	requestUpdate = "update"
+	requestDelete = "delete"
+
+	requestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "user_request_success_total",
+		Help: "The total number of successful requests",
+	}, []string{"request_type"})
+
+	requestFailure = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "user_request_failure_total",
+		Help: "The total number of failed requests",
+	}, []string{"request_type", "error_code"})
+)

--- a/user/user.go
+++ b/user/user.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 
 	"github.com/TempleEight/spec-golang/user/dao"
 	"github.com/TempleEight/spec-golang/user/util"
@@ -104,6 +105,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusUnauthorized)
+		requestFailure.WithLabelValues(requestCreate, strconv.Itoa(http.StatusUnauthorized)).Inc()
 		return
 	}
 
@@ -112,6 +114,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusBadRequest)
+		requestFailure.WithLabelValues(requestCreate, strconv.Itoa(http.StatusBadRequest)).Inc()
 		return
 	}
 
@@ -119,6 +122,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusBadRequest)
+		requestFailure.WithLabelValues(requestCreate, strconv.Itoa(http.StatusBadRequest)).Inc()
 		return
 	}
 
@@ -132,6 +136,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			errMsg := util.CreateErrorJSON(err.Error())
 			http.Error(w, errMsg, err.statusCode)
+			requestFailure.WithLabelValues(requestCreate, strconv.Itoa(err.statusCode)).Inc()
 			return
 		}
 	}
@@ -140,6 +145,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
+		requestFailure.WithLabelValues(requestCreate, strconv.Itoa(http.StatusInternalServerError)).Inc()
 		return
 	}
 
@@ -148,6 +154,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			errMsg := util.CreateErrorJSON(err.Error())
 			http.Error(w, errMsg, err.statusCode)
+			requestFailure.WithLabelValues(requestCreate, strconv.Itoa(err.statusCode)).Inc()
 			return
 		}
 	}
@@ -156,6 +163,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		ID:   user.ID,
 		Name: user.Name,
 	})
+	requestSuccess.WithLabelValues(requestCreate).Inc()
 }
 
 func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
@@ -210,6 +218,7 @@ func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 		ID:   user.ID,
 		Name: user.Name,
 	})
+	requestSuccess.WithLabelValues(requestRead).Inc()
 }
 
 func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
@@ -287,6 +296,7 @@ func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 		ID:   user.ID,
 		Name: user.Name,
 	})
+	requestSuccess.WithLabelValues(requestUpdate).Inc()
 }
 
 func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
@@ -345,4 +355,5 @@ func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(struct{}{})
+	requestSuccess.WithLabelValues(requestDelete).Inc()
 }

--- a/user/user.go
+++ b/user/user.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/TempleEight/spec-golang/user/dao"
+	"github.com/TempleEight/spec-golang/user/metric"
 	"github.com/TempleEight/spec-golang/user/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
@@ -105,7 +106,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Could not authorize request: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusUnauthorized)
-		requestFailure.WithLabelValues(requestCreate, strconv.Itoa(http.StatusUnauthorized)).Inc()
+		metric.RequestFailure.WithLabelValues(metric.RequestCreate, strconv.Itoa(http.StatusUnauthorized)).Inc()
 		return
 	}
 
@@ -114,7 +115,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusBadRequest)
-		requestFailure.WithLabelValues(requestCreate, strconv.Itoa(http.StatusBadRequest)).Inc()
+		metric.RequestFailure.WithLabelValues(metric.RequestCreate, strconv.Itoa(http.StatusBadRequest)).Inc()
 		return
 	}
 
@@ -122,7 +123,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Invalid request parameters: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusBadRequest)
-		requestFailure.WithLabelValues(requestCreate, strconv.Itoa(http.StatusBadRequest)).Inc()
+		metric.RequestFailure.WithLabelValues(metric.RequestCreate, strconv.Itoa(http.StatusBadRequest)).Inc()
 		return
 	}
 
@@ -136,7 +137,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			errMsg := util.CreateErrorJSON(err.Error())
 			http.Error(w, errMsg, err.statusCode)
-			requestFailure.WithLabelValues(requestCreate, strconv.Itoa(err.statusCode)).Inc()
+			metric.RequestFailure.WithLabelValues(metric.RequestCreate, strconv.Itoa(err.statusCode)).Inc()
 			return
 		}
 	}
@@ -145,7 +146,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
-		requestFailure.WithLabelValues(requestCreate, strconv.Itoa(http.StatusInternalServerError)).Inc()
+		metric.RequestFailure.WithLabelValues(metric.RequestCreate, strconv.Itoa(http.StatusInternalServerError)).Inc()
 		return
 	}
 
@@ -154,7 +155,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			errMsg := util.CreateErrorJSON(err.Error())
 			http.Error(w, errMsg, err.statusCode)
-			requestFailure.WithLabelValues(requestCreate, strconv.Itoa(err.statusCode)).Inc()
+			metric.RequestFailure.WithLabelValues(metric.RequestCreate, strconv.Itoa(err.statusCode)).Inc()
 			return
 		}
 	}
@@ -163,7 +164,7 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		ID:   user.ID,
 		Name: user.Name,
 	})
-	requestSuccess.WithLabelValues(requestCreate).Inc()
+	metric.RequestSuccess.WithLabelValues(metric.RequestCreate).Inc()
 }
 
 func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
@@ -218,7 +219,7 @@ func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 		ID:   user.ID,
 		Name: user.Name,
 	})
-	requestSuccess.WithLabelValues(requestRead).Inc()
+	metric.RequestSuccess.WithLabelValues(metric.RequestRead).Inc()
 }
 
 func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
@@ -296,7 +297,7 @@ func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 		ID:   user.ID,
 		Name: user.Name,
 	})
-	requestSuccess.WithLabelValues(requestUpdate).Inc()
+	metric.RequestSuccess.WithLabelValues(metric.RequestUpdate).Inc()
 }
 
 func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
@@ -355,5 +356,5 @@ func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(struct{}{})
-	requestSuccess.WithLabelValues(requestDelete).Inc()
+	metric.RequestSuccess.WithLabelValues(metric.RequestDelete).Inc()
 }


### PR DESCRIPTION
- Add some custom metrics to the user service
- Show success and failure rate charts, averaged over the last 5 mins

The way in which you add a failure metric is kinda annoying, there's lots of repeated code - I'm gonna pull this out into a utility function before adding any more.

Also apologies for the JSON.. looks like I've just found what I'm generating for the next few days ❤️ 

Currently looks like:

<img width="1920" alt="Screenshot 2020-03-18 at 16 20 06" src="https://user-images.githubusercontent.com/16157582/76984635-01a61200-6937-11ea-91ae-8190f439d855.png">
