### PR TITLE
[metrics][user] Add database query time metric

### DIFF
--- a/grafana/provisioning/dashboards/user.json
+++ b/grafana/provisioning/dashboards/user.json
@@ -15,7 +15,7 @@
     "editable": true,
     "gnetId": null,
     "graphTooltip": 0,
-    "id": 2,
+    "id": 1,
     "links": [],
     "panels": [
         {
@@ -27,7 +27,7 @@
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
-                "h": 6,
+                "h": 5,
                 "w": 12,
                 "x": 0,
                 "y": 0
@@ -119,14 +119,117 @@
             "bars": false,
             "dashLength": 10,
             "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 0
+            },
+            "hiddenSeries": false,
+            "id": 7,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.5\",query_type=\"create\"}",
+                    "legendFormat": "50th Percentile",
+                    "refId": "A"
+                },
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.9\",query_type=\"create\"}",
+                    "legendFormat": "90th Percentile",
+                    "refId": "B"
+                },
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.95\",query_type=\"create\"}",
+                    "legendFormat": "95th Percentile",
+                    "refId": "C"
+                },
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.99\",query_type=\"create\"}",
+                    "legendFormat": "99th Percentile",
+                    "refId": "D"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "DB Create Queries",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": "Time (seconds)",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
             "datasource": "Prometheus",
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
-                "h": 6,
+                "h": 5,
                 "w": 12,
-                "x": 12,
-                "y": 0
+                "x": 0,
+                "y": 5
             },
             "hiddenSeries": false,
             "id": 3,
@@ -215,14 +318,117 @@
             "bars": false,
             "dashLength": 10,
             "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 5
+            },
+            "hiddenSeries": false,
+            "id": 10,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.5\",query_type=\"read\"}",
+                    "legendFormat": "50th Percentile",
+                    "refId": "A"
+                },
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.9\",query_type=\"read\"}",
+                    "legendFormat": "90th Percentile",
+                    "refId": "B"
+                },
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.95\",query_type=\"read\"}",
+                    "legendFormat": "95th Percentile",
+                    "refId": "C"
+                },
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.99\",query_type=\"read\"}",
+                    "legendFormat": "99th Percentile",
+                    "refId": "D"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "DB Read Queries",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": "Time (seconds)",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
             "datasource": "Prometheus",
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
-                "h": 6,
+                "h": 5,
                 "w": 12,
                 "x": 0,
-                "y": 6
+                "y": 10
             },
             "hiddenSeries": false,
             "id": 5,
@@ -311,14 +517,117 @@
             "bars": false,
             "dashLength": 10,
             "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.5\",query_type=\"update\"}",
+                    "legendFormat": "50th Percentile",
+                    "refId": "A"
+                },
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.9\",query_type=\"update\"}",
+                    "legendFormat": "90th Percentile",
+                    "refId": "B"
+                },
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.95\",query_type=\"update\"}",
+                    "legendFormat": "95th Percentile",
+                    "refId": "C"
+                },
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.99\",query_type=\"update\"}",
+                    "legendFormat": "99th Percentile",
+                    "refId": "D"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "DB Update Queries",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": "Time (seconds)",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
             "datasource": "Prometheus",
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
-                "h": 6,
+                "h": 5,
                 "w": 12,
-                "x": 12,
-                "y": 6
+                "x": 0,
+                "y": 15
             },
             "hiddenSeries": false,
             "id": 4,
@@ -383,6 +692,109 @@
                 {
                     "format": "short",
                     "label": "QPS",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 15
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.5\",query_type=\"delete\"}",
+                    "legendFormat": "50th Percentile",
+                    "refId": "A"
+                },
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.9\",query_type=\"delete\"}",
+                    "legendFormat": "90th Percentile",
+                    "refId": "B"
+                },
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.95\",query_type=\"delete\"}",
+                    "legendFormat": "95th Percentile",
+                    "refId": "C"
+                },
+                {
+                    "expr": "user_database_request_seconds{quantile=\"0.99\",query_type=\"delete\"}",
+                    "legendFormat": "99th Percentile",
+                    "refId": "D"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "DB Delete Queries",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": "Time (seconds)",
                     "logBase": 1,
                     "max": null,
                     "min": null,

--- a/user/metric/metric.go
+++ b/user/metric/metric.go
@@ -20,4 +20,10 @@ var (
 		Name: "user_request_failure_total",
 		Help: "The total number of failed requests",
 	}, []string{"request_type", "error_code"})
+
+	DatabaseRequestDuration = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "user_database_request_seconds",
+		Help:       "The time spent executing database requests in seconds",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
+	}, []string{"query_type"})
 )

--- a/user/user.go
+++ b/user/user.go
@@ -8,14 +8,13 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/TempleEight/spec-golang/user/dao"
 	"github.com/TempleEight/spec-golang/user/metric"
 	"github.com/TempleEight/spec-golang/user/util"
 	valid "github.com/asaskevich/govalidator"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 

--- a/user/user.go
+++ b/user/user.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/TempleEight/spec-golang/user/dao"
 	"github.com/TempleEight/spec-golang/user/metric"
 	"github.com/TempleEight/spec-golang/user/util"
@@ -142,7 +144,10 @@ func (env *env) createUserHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestCreate))
 	user, err := env.dao.CreateUser(input)
+	timer.ObserveDuration()
+
 	if err != nil {
 		errMsg := util.CreateErrorJSON(fmt.Sprintf("Something went wrong: %s", err.Error()))
 		http.Error(w, errMsg, http.StatusInternalServerError)
@@ -194,7 +199,10 @@ func (env *env) readUserHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestRead))
 	user, err := env.dao.ReadUser(input)
+	timer.ObserveDuration()
+
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrUserNotFound:
@@ -272,7 +280,10 @@ func (env *env) updateUserHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestUpdate))
 	user, err := env.dao.UpdateUser(input)
+	timer.ObserveDuration()
+
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrUserNotFound:
@@ -334,7 +345,10 @@ func (env *env) deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	timer := prometheus.NewTimer(metric.DatabaseRequestDuration.WithLabelValues(metric.RequestDelete))
 	err = env.dao.DeleteUser(input)
+	timer.ObserveDuration()
+
 	if err != nil {
 		switch err.(type) {
 		case dao.ErrUserNotFound:


### PR DESCRIPTION
- Add a new metric to measure DB request times, bucketed into 50th, 90th, 95th and 99th percentiles. 

<img width="1680" alt="Screenshot 2020-03-19 at 10 23 36" src="https://user-images.githubusercontent.com/16157582/77058743-c0147600-69cd-11ea-9f72-b1a34661cc2c.png">
