### PR TITLE
[deploy] Add basedir to files

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,8 @@
 #! /bin/sh
 # Deployment script for kube - generates configmaps from SQL init files and provisions everything
 
+BASEDIR=$(dirname "$0")
+
 GREEN="\033[1;32m"
 BLUE="\033[1;34m"
 YELLOW="\033[1;33m"
@@ -12,11 +14,11 @@ minikube start --vm-driver=virtualbox
 echo $GREEN
 
 kubectl create secret docker-registry regcred --docker-server=$REG_URL --docker-username=$REG_USERNAME --docker-password=$REG_PASSWORD --docker-email=$REG_EMAIL
-kubectl create configmap match-db-config --from-file match-db/init.sql -o=yaml
-kubectl create configmap user-db-config --from-file user-db/init.sql -o=yaml
-kubectl create configmap auth-db-config --from-file auth-db/init.sql -o=yaml
+kubectl create configmap match-db-config --from-file $BASEDIR/match-db/init.sql -o=yaml
+kubectl create configmap user-db-config --from-file $BASEDIR/user-db/init.sql -o=yaml
+kubectl create configmap auth-db-config --from-file $BASEDIR/auth-db/init.sql -o=yaml
 
-for dir in kube/*
+for dir in $BASEDIR/kube/*
 do
   kubectl create -f $dir
 done
@@ -50,7 +52,7 @@ echo Configuring Kong...
 
 sleep 1
 
-sh kong/configure-kong-k8s.sh
+sh $BASEDIR/kong/configure-kong-k8s.sh
 
 echo $PURPLE
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 # Deployment script for kube - generates configmaps from SQL init files and provisions everything
 
-BASEDIR=$(dirname "$0")
+BASEDIR=$(dirname "$BASH_SOURCE")
 
 GREEN="\033[1;32m"
 BLUE="\033[1;34m"

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,11 +14,11 @@ minikube start --vm-driver=virtualbox
 echo $GREEN
 
 kubectl create secret docker-registry regcred --docker-server=$REG_URL --docker-username=$REG_USERNAME --docker-password=$REG_PASSWORD --docker-email=$REG_EMAIL
-kubectl create configmap match-db-config --from-file $BASEDIR/match-db/init.sql -o=yaml
-kubectl create configmap user-db-config --from-file $BASEDIR/user-db/init.sql -o=yaml
-kubectl create configmap auth-db-config --from-file $BASEDIR/auth-db/init.sql -o=yaml
+kubectl create configmap match-db-config --from-file "$BASEDIR/match-db/init.sql" -o=yaml
+kubectl create configmap user-db-config --from-file "$BASEDIR/user-db/init.sql" -o=yaml
+kubectl create configmap auth-db-config --from-file "$BASEDIR/auth-db/init.sql" -o=yaml
 
-for dir in $BASEDIR/kube/*
+for dir in "$BASEDIR/kube/"*
 do
   kubectl create -f $dir
 done
@@ -52,7 +52,7 @@ echo Configuring Kong...
 
 sleep 1
 
-sh $BASEDIR/kong/configure-kong-k8s.sh
+sh "$BASEDIR/kong/configure-kong-k8s.sh"
 
 echo $PURPLE
 

--- a/kong/configure-kong-k8s.sh
+++ b/kong/configure-kong-k8s.sh
@@ -1,47 +1,47 @@
 #!/bin/sh
 
 # Add the user service
-curl -i -X POST \
+curl -s -i -X POST \
   --url $KONG_ADMIN/services/ \
   --data 'name=user-service' \
   --data 'url=http://user:80/user'
 
 # Add the match service
-curl -i -X POST \
+curl -s -i -X POST \
   --url $KONG_ADMIN/services/ \
   --data 'name=match-service' \
   --data 'url=http://match:81/match'
 
 # Add the auth service
-curl -i -X POST \
+curl -s -i -X POST \
   --url $KONG_ADMIN/services/ \
   --data 'name=auth-service' \
   --data 'url=http://auth:82/auth'
 
 # Add a route for user
-curl -i -X POST \
+curl -s -i -X POST \
   --url $KONG_ADMIN/services/user-service/routes \
   --data "hosts[]=$KONG_ENTRY" \
   --data 'paths[]=/api/user'
 
 # Add a route for match
-curl -i -X POST \
+curl -s -i -X POST \
   --url $KONG_ADMIN/services/match-service/routes \
   --data "hosts[]=$KONG_ENTRY" \
   --data 'paths[]=/api/match'
 
 # Add a route for auth
-curl -i -X POST \
+curl -s -i -X POST \
   --url $KONG_ADMIN/services/auth-service/routes \
   --data "hosts[]=$KONG_ENTRY" \
   --data 'paths[]=/api/auth'
 
 # Require a JWT for the user service
-curl -X POST $KONG_ADMIN/services/user-service/plugins \
+curl -s -X POST $KONG_ADMIN/services/user-service/plugins \
     --data "name=jwt"\
     --data "config.claims_to_verify=exp"
 
 # Require a JWT for the match service
-curl -X POST $KONG_ADMIN/services/match-service/plugins \
+curl -s -X POST $KONG_ADMIN/services/match-service/plugins \
     --data "name=jwt"\
     --data "config.claims_to_verify=exp"


### PR DESCRIPTION
So we can run the deployment script from anywhere, make each path used include the base part of the directory too.

Test Plan:

From any directory run `source path/to/spec-golang/deploy.sh`