### PR TITLE
[user] Add picture struct create endpoint

### DIFF
--- a/user-db/init.sql
+++ b/user-db/init.sql
@@ -2,3 +2,9 @@ CREATE TABLE user_temple (
   id UUID PRIMARY KEY,
   name TEXT
 );
+
+CREATE TABLE picture (
+  id UUID PRIMARY KEY,
+  user_id UUID REFERENCES user_temple(id),
+  img BYTEA
+);

--- a/user/hook.go
+++ b/user/hook.go
@@ -5,15 +5,17 @@ import "github.com/TempleEight/spec-golang/user/dao"
 // Hook allows additional code to be executed before and after every datastore interaction
 // Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
 type Hook struct {
-	beforeCreateHooks []*func(env *env, req createUserRequest, input *dao.CreateUserInput) *HookError
-	beforeReadHooks   []*func(env *env, input *dao.ReadUserInput) *HookError
-	beforeUpdateHooks []*func(env *env, req updateUserRequest, input *dao.UpdateUserInput) *HookError
-	beforeDeleteHooks []*func(env *env, input *dao.DeleteUserInput) *HookError
+	beforeCreateHooks        []*func(env *env, req createUserRequest, input *dao.CreateUserInput) *HookError
+	beforeReadHooks          []*func(env *env, input *dao.ReadUserInput) *HookError
+	beforeUpdateHooks        []*func(env *env, req updateUserRequest, input *dao.UpdateUserInput) *HookError
+	beforeDeleteHooks        []*func(env *env, input *dao.DeleteUserInput) *HookError
+	beforeCreatePictureHooks []*func(env *env, req createPictureRequest, input *dao.CreatePictureInput) *HookError
 
-	afterCreateHooks []*func(env *env, user *dao.User) *HookError
-	afterReadHooks   []*func(env *env, user *dao.User) *HookError
-	afterUpdateHooks []*func(env *env, user *dao.User) *HookError
-	afterDeleteHooks []*func(env *env) *HookError
+	afterCreateHooks        []*func(env *env, user *dao.User) *HookError
+	afterReadHooks          []*func(env *env, user *dao.User) *HookError
+	afterUpdateHooks        []*func(env *env, user *dao.User) *HookError
+	afterDeleteHooks        []*func(env *env) *HookError
+	afterCreatePictureHooks []*func(env *env, picture *dao.Picture) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -46,6 +48,11 @@ func (h *Hook) BeforeDelete(hook func(env *env, input *dao.DeleteUserInput) *Hoo
 	h.beforeDeleteHooks = append(h.beforeDeleteHooks, &hook)
 }
 
+// BeforeCreate adds a new hook to be executed before creating an object in the datastore
+func (h *Hook) BeforeCreatePicture(hook func(env *env, req createPictureRequest, input *dao.CreatePictureInput) *HookError) {
+	h.beforeCreatePictureHooks = append(h.beforeCreatePictureHooks, &hook)
+}
+
 // AfterCreate adds a new hook to be executed after creating an object in the datastore
 func (h *Hook) AfterCreate(hook func(env *env, user *dao.User) *HookError) {
 	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
@@ -64,4 +71,9 @@ func (h *Hook) AfterUpdate(hook func(env *env, user *dao.User) *HookError) {
 // AfterDelete adds a new hook to be executed after deleting an object in the datastore
 func (h *Hook) AfterDelete(hook func(env *env) *HookError) {
 	h.afterDeleteHooks = append(h.afterDeleteHooks, &hook)
+}
+
+// AfterCreatePicture adds a new hook to be executed after creating an object in the datastore
+func (h *Hook) AfterCreatePicture(hook func(env *env, user *dao.Picture) *HookError) {
+	h.afterCreatePictureHooks = append(h.afterCreatePictureHooks, &hook)
 }

--- a/user/metric/metric.go
+++ b/user/metric/metric.go
@@ -10,6 +10,7 @@ var (
 	RequestRead   = "read"
 	RequestUpdate = "update"
 	RequestDelete = "delete"
+	RequestCreatePicture = "create_picture"
 
 	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "user_request_success_total",


### PR DESCRIPTION
Add support for a `picture` struct in the `user` service, which involves a couple of design decisions:

- Adds a new endpoint `user/<id>/picture` with CRUD defined on that (C now, RUD coming later)
- Implicit foreign key constraint on the picture table, but never returned
- Whenever a byte array is used it is NOT returned in the response body
- Byte arrays are expected to be encoded into base64 whenever used in JSON


Have added unit tests for this endpoint, but for those that like manual testing too:

```bash
ACCESS1=$(curl -s -X POST $BASE/api/auth/register -d "{\"email\":\"jay$RANDOM@test.com\", \"password\":\"abcdefgh\"}" | jq -r .AccessToken)

USER1=$(curl -s -X POST $BASE/api/user -d '{"name": "Jay"}' -H "Authorization: Bearer $ACCESS1" | jq -r .ID)

CAT=$(base64 ~/cat.png)

echo "{ \"img\": \"$CAT\" }" | curl -X POST $BASE/api/user/$USER1/picture -H "Authorization: Bearer $ACCESS1" -d @-

```
