### PR TITLE
[user] Add read picture endpoint

### DIFF
--- a/user/dao/errors.go
+++ b/user/dao/errors.go
@@ -8,3 +8,10 @@ type ErrUserNotFound string
 func (e ErrUserNotFound) Error() string {
 	return fmt.Sprintf("user not found with ID %s", string(e))
 }
+
+// ErrPictureNotFound is returned when a picture for the provided ID was not found
+type ErrPictureNotFound string
+
+func (e ErrPictureNotFound) Error() string {
+	return fmt.Sprintf("picture not found with ID %s", string(e))
+}

--- a/user/hook.go
+++ b/user/hook.go
@@ -10,12 +10,14 @@ type Hook struct {
 	beforeUpdateHooks        []*func(env *env, req updateUserRequest, input *dao.UpdateUserInput) *HookError
 	beforeDeleteHooks        []*func(env *env, input *dao.DeleteUserInput) *HookError
 	beforeCreatePictureHooks []*func(env *env, req createPictureRequest, input *dao.CreatePictureInput) *HookError
+	beforeReadPictureHooks   []*func(env *env, input *dao.ReadPictureInput) *HookError
 
 	afterCreateHooks        []*func(env *env, user *dao.User) *HookError
 	afterReadHooks          []*func(env *env, user *dao.User) *HookError
 	afterUpdateHooks        []*func(env *env, user *dao.User) *HookError
 	afterDeleteHooks        []*func(env *env) *HookError
 	afterCreatePictureHooks []*func(env *env, picture *dao.Picture) *HookError
+	afterReadPictureHooks   []*func(env *env, picture *dao.Picture) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -48,9 +50,14 @@ func (h *Hook) BeforeDelete(hook func(env *env, input *dao.DeleteUserInput) *Hoo
 	h.beforeDeleteHooks = append(h.beforeDeleteHooks, &hook)
 }
 
-// BeforeCreate adds a new hook to be executed before creating an object in the datastore
+// BeforeCreatePicture adds a new hook to be executed before creating an object in the datastore
 func (h *Hook) BeforeCreatePicture(hook func(env *env, req createPictureRequest, input *dao.CreatePictureInput) *HookError) {
 	h.beforeCreatePictureHooks = append(h.beforeCreatePictureHooks, &hook)
+}
+
+// BeforeReadPicture adds a new hook to be executed before reading an object in the datastore
+func (h *Hook) BeforeReadPicture(hook func(env *env, input *dao.ReadPictureInput) *HookError) {
+	h.beforeReadPictureHooks = append(h.beforeReadPictureHooks, &hook)
 }
 
 // AfterCreate adds a new hook to be executed after creating an object in the datastore
@@ -76,4 +83,9 @@ func (h *Hook) AfterDelete(hook func(env *env) *HookError) {
 // AfterCreatePicture adds a new hook to be executed after creating an object in the datastore
 func (h *Hook) AfterCreatePicture(hook func(env *env, user *dao.Picture) *HookError) {
 	h.afterCreatePictureHooks = append(h.afterCreatePictureHooks, &hook)
+}
+
+// AfterReadPicture adds a new hook to be executed after reading an object in the datastore
+func (h *Hook) AfterReadPicture(hook func(env *env, user *dao.Picture) *HookError) {
+	h.afterReadPictureHooks = append(h.afterReadPictureHooks, &hook)
 }

--- a/user/metric/metric.go
+++ b/user/metric/metric.go
@@ -6,11 +6,12 @@ import (
 )
 
 var (
-	RequestCreate = "create"
-	RequestRead   = "read"
-	RequestUpdate = "update"
-	RequestDelete = "delete"
+	RequestCreate        = "create"
+	RequestRead          = "read"
+	RequestUpdate        = "update"
+	RequestDelete        = "delete"
 	RequestCreatePicture = "create_picture"
+	RequestReadPicture   = "read_picture"
 
 	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "user_request_success_total",

--- a/user/util/util.go
+++ b/user/util/util.go
@@ -42,11 +42,21 @@ func CreateErrorJSON(message string) string {
 	return string(json)
 }
 
-// ExtractIDFromRequest extracts the parameter provided under parameter ID and converts it into a string
+// ExtractIDFromRequest extracts the parameter provided under parameter ID and converts it into a uuid
 func ExtractIDFromRequest(requestParams map[string]string) (uuid.UUID, error) {
 	id := requestParams["id"]
 	if len(id) == 0 {
 		return uuid.Nil, errors.New("No ID provided")
+	}
+
+	return uuid.Parse(id)
+}
+
+// ExtractPictureIDFromRequest extracts the parameter provided under parameter picture_id and converts it into a uuid
+func ExtractPictureIDFromRequest(requestParams map[string]string) (uuid.UUID, error) {
+	id := requestParams["picture_id"]
+	if len(id) == 0 {
+		return uuid.Nil, errors.New("No Picture ID provided")
 	}
 
 	return uuid.Parse(id)


### PR DESCRIPTION
Add read picture endpoint - pretty standard stuff, although had to think a little bit about it since:

- Any user can read any other user's pictures (`#writable(by: all)`)
- The database query needs an `AND`, so that you the picture accessed is correctly associated with the given user

Some beautiful manual testing:

```
ACCESS1=$(curl -s -X POST $BASE/api/auth/register -d "{\"email\":\"jay$RANDOM@test.com\", \"password\":\"abcdefgh\"}" | jq -r .AccessToken)

USER1=$(curl -s -X POST $BASE/api/user -d '{"name": "Jay"}' -H "Authorization: Bearer $ACCESS1" | jq -r .ID)

CAT=$(base64 ~/cat.png)

PIC_ID=$(echo "{ \"img\": \"$CAT\" }" | curl -X POST $BASE/api/user/$USER1/picture -H "Authorization: Bearer $ACCESS1" -d @- | jq -r .ID)

curl -s -X GET $BASE/api/user/$USER1/picture/$PIC_ID -H "Authorization: Bearer $ACCESS1" | jq -r .Img | base64 -d > cat_reply.png

cmp ~/cat.png cat_reply.png || echo "files are different"
```

And as requested, `cat.png`:
![](https://pngimg.com/uploads/cat/cat_PNG50504.png)
