### PR TITLE
[user] Add update picture endpoint

### DIFF
--- a/user/hook.go
+++ b/user/hook.go
@@ -11,6 +11,7 @@ type Hook struct {
 	beforeDeleteHooks        []*func(env *env, input *dao.DeleteUserInput) *HookError
 	beforeCreatePictureHooks []*func(env *env, req createPictureRequest, input *dao.CreatePictureInput) *HookError
 	beforeReadPictureHooks   []*func(env *env, input *dao.ReadPictureInput) *HookError
+	beforeUpdatePictureHooks []*func(env *env, req updatePictureRequest, input *dao.UpdatePictureInput) *HookError
 
 	afterCreateHooks        []*func(env *env, user *dao.User) *HookError
 	afterReadHooks          []*func(env *env, user *dao.User) *HookError
@@ -18,6 +19,7 @@ type Hook struct {
 	afterDeleteHooks        []*func(env *env) *HookError
 	afterCreatePictureHooks []*func(env *env, picture *dao.Picture) *HookError
 	afterReadPictureHooks   []*func(env *env, picture *dao.Picture) *HookError
+	afterUpdatePictureHooks []*func(env *env, picture *dao.Picture) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -60,6 +62,11 @@ func (h *Hook) BeforeReadPicture(hook func(env *env, input *dao.ReadPictureInput
 	h.beforeReadPictureHooks = append(h.beforeReadPictureHooks, &hook)
 }
 
+// BeforeUpdatePicture adds a new hook to be executed before reading an object in the datastore
+func (h *Hook) BeforeUpdatePicture(hook func(env *env, req updatePictureRequest, input *dao.UpdatePictureInput) *HookError) {
+	h.beforeUpdatePictureHooks = append(h.beforeUpdatePictureHooks, &hook)
+}
+
 // AfterCreate adds a new hook to be executed after creating an object in the datastore
 func (h *Hook) AfterCreate(hook func(env *env, user *dao.User) *HookError) {
 	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
@@ -88,4 +95,9 @@ func (h *Hook) AfterCreatePicture(hook func(env *env, user *dao.Picture) *HookEr
 // AfterReadPicture adds a new hook to be executed after reading an object in the datastore
 func (h *Hook) AfterReadPicture(hook func(env *env, user *dao.Picture) *HookError) {
 	h.afterReadPictureHooks = append(h.afterReadPictureHooks, &hook)
+}
+
+// AfterUpdatePicture adds a new hook to be executed after reading an object in the datastore
+func (h *Hook) AfterUpdatePicture(hook func(env *env, user *dao.Picture) *HookError) {
+	h.afterUpdatePictureHooks = append(h.afterUpdatePictureHooks, &hook)
 }

--- a/user/metric/metric.go
+++ b/user/metric/metric.go
@@ -12,6 +12,7 @@ var (
 	RequestDelete        = "delete"
 	RequestCreatePicture = "create_picture"
 	RequestReadPicture   = "read_picture"
+	RequestUpdatePicture = "update_picture"
 
 	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "user_request_success_total",


### PR DESCRIPTION
Add update picture endpoint to the user service. I LOVE writing tests.

For some manual testing:

```
BASE=${KONG_ENTRY:-"localhost:8000"}
CAT=$(base64 ~/Downloads/cat.png)
DOG=$(base64 ~/Downloads/dog.png)

# Create access
ACCESS1=$(curl -s -X POST $BASE/api/auth/register -d "{\"email\":\"jay$RANDOM@test.com\", \"password\":\"abcdefgh\"}" | jq -r .AccessToken)

# Create user
USER1=$(curl -s -X POST $BASE/api/user -d '{"name": "Jay"}' -H "Authorization: Bearer $ACCESS1" | jq -r .ID)

# Create picture
PIC_ID=$(echo "{ \"img\": \"$CAT\" }" | curl -s -X POST $BASE/api/user/$USER1/picture -H "Authorization: Bearer $ACCESS1" -d @- | jq -r .ID)

# Get Picture
curl -s -X GET $BASE/api/user/$USER1/picture/$PIC_ID -H "Authorization: Bearer $ACCESS1" | jq -r .Img | base64 -d > cat_reply.png

# Update cat to dog
echo "{ \"img\": \"$DOG\" }" | curl -s -X PUT $BASE/api/user/$USER1/picture/$PIC_ID -H "Authorization: Bearer $ACCESS1" -d @-

# Get dog
curl -s -X GET $BASE/api/user/$USER1/picture/$PIC_ID -H "Authorization: Bearer $ACCESS1" | jq -r .Img | base64 -d > dog_reply.png

# Check right thing was returned
cmp ~/Downloads/cat.png cat_reply.png || echo "cat files are different"
cmp ~/Downloads/dog.png dog_reply.png || echo "dog files are different"
```

And the required files:
![dog](https://user-images.githubusercontent.com/16157582/78257792-3fd43180-74f2-11ea-8a7a-2a10296d0998.png)
![cat](https://user-images.githubusercontent.com/16157582/78257802-42368b80-74f2-11ea-9cf2-f2aac9a4fd05.png)

