### PR TITLE
[auth] Rename hooks to register and login

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -156,7 +156,7 @@ func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {
 		Password: string(hashedPassword),
 	}
 
-	for _, hook := range env.hook.beforeCreateHooks {
+	for _, hook := range env.hook.beforeRegisterHooks {
 		err := (*hook)(env, req, &input)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRegister)
@@ -183,7 +183,7 @@ func (env *env) registerAuthHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterCreateHooks {
+	for _, hook := range env.hook.afterRegisterHooks {
 		err := (*hook)(env, auth, accessToken)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestRegister)
@@ -215,7 +215,7 @@ func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
 		Email: req.Email,
 	}
 
-	for _, hook := range env.hook.beforeReadHooks {
+	for _, hook := range env.hook.beforeLoginHooks {
 		err := (*hook)(env, req, &input)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestLogin)
@@ -248,7 +248,7 @@ func (env *env) loginAuthHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, hook := range env.hook.afterReadHooks {
+	for _, hook := range env.hook.afterLoginHooks {
 		err := (*hook)(env, auth, accessToken)
 		if err != nil {
 			respondWithError(w, err.Error(), err.statusCode, metric.RequestLogin)

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -200,12 +200,12 @@ func TestCreateAuthHandlerFailsOnDuplicate(t *testing.T) {
 	}
 }
 
-// Test that a before create hook is successfully invoked
+// Test that a before register hook is successfully invoked
 func TestCreateAuthHandlerBeforeHookSucceeds(t *testing.T) {
 	mockEnv := makeMockEnv()
 	isHookExecuted := false
 
-	mockEnv.hook.BeforeCreate(func(env *env, req registerAuthRequest, input *dao.CreateAuthInput) *HookError {
+	mockEnv.hook.BeforeRegister(func(env *env, req registerAuthRequest, input *dao.CreateAuthInput) *HookError {
 		isHookExecuted = true
 		return nil
 	})
@@ -225,11 +225,11 @@ func TestCreateAuthHandlerBeforeHookSucceeds(t *testing.T) {
 	}
 }
 
-// Test that a before create hook is successfully invoked and request is aborted
+// Test that a before register hook is successfully invoked and request is aborted
 func TestCreateUserHandlerBeforeHookAbortsRequest(t *testing.T) {
 	mockEnv := makeMockEnv()
 
-	mockEnv.hook.BeforeCreate(func(env *env, req registerAuthRequest, input *dao.CreateAuthInput) *HookError {
+	mockEnv.hook.BeforeRegister(func(env *env, req registerAuthRequest, input *dao.CreateAuthInput) *HookError {
 		return &HookError{http.StatusTeapot, errors.New("Example")}
 	})
 
@@ -244,12 +244,12 @@ func TestCreateUserHandlerBeforeHookAbortsRequest(t *testing.T) {
 	}
 }
 
-// Test that an after create hook is successfully invoked
+// Test that an after register hook is successfully invoked
 func TestCreateUserHandlerAfterHookSucceeds(t *testing.T) {
 	mockEnv := makeMockEnv()
 	isHookExecuted := false
 
-	mockEnv.hook.AfterCreate(func(env *env, auth *dao.Auth, accessToken string) *HookError {
+	mockEnv.hook.AfterRegister(func(env *env, auth *dao.Auth, accessToken string) *HookError {
 		isHookExecuted = true
 		return nil
 	})
@@ -269,11 +269,11 @@ func TestCreateUserHandlerAfterHookSucceeds(t *testing.T) {
 	}
 }
 
-// Test that an after create hook is successfully invoked
+// Test that an after register hook is successfully invoked
 func TestCreateUserHandlerAfterHookAbortsRequest(t *testing.T) {
 	mockEnv := makeMockEnv()
 
-	mockEnv.hook.AfterCreate(func(env *env, auth *dao.Auth, accessToken string) *HookError {
+	mockEnv.hook.AfterRegister(func(env *env, auth *dao.Auth, accessToken string) *HookError {
 		return &HookError{http.StatusTeapot, errors.New("Example")}
 	})
 
@@ -405,12 +405,12 @@ func TestReadAuthHandlerFailsOnNonExistentAuth(t *testing.T) {
 	}
 }
 
-// Test that a before read hook is successfully invoked
+// Test that a before login hook is successfully invoked
 func TestReadAuthHandlerBeforeHookSucceeds(t *testing.T) {
 	mockEnv := makeMockEnv()
 	isHookExecuted := false
 
-	mockEnv.hook.BeforeRead(func(env *env, req loginAuthRequest, input *dao.ReadAuthInput) *HookError {
+	mockEnv.hook.BeforeLogin(func(env *env, req loginAuthRequest, input *dao.ReadAuthInput) *HookError {
 		isHookExecuted = true
 		return nil
 	})
@@ -436,11 +436,11 @@ func TestReadAuthHandlerBeforeHookSucceeds(t *testing.T) {
 	}
 }
 
-// Test that a before read hook is successfully invoked and request is aborted
+// Test that a before login hook is successfully invoked and request is aborted
 func TestReadAuthHandlerBeforeHookAbortsRequest(t *testing.T) {
 	mockEnv := makeMockEnv()
 
-	mockEnv.hook.BeforeRead(func(env *env, req loginAuthRequest, input *dao.ReadAuthInput) *HookError {
+	mockEnv.hook.BeforeLogin(func(env *env, req loginAuthRequest, input *dao.ReadAuthInput) *HookError {
 		return &HookError{http.StatusTeapot, errors.New("Example")}
 	})
 
@@ -461,12 +461,12 @@ func TestReadAuthHandlerBeforeHookAbortsRequest(t *testing.T) {
 	}
 }
 
-// Test that an after create hook is successfully invoked
+// Test that an after login hook is successfully invoked
 func TestReadAuthHandlerAfterHookSucceeds(t *testing.T) {
 	mockEnv := makeMockEnv()
 	isHookExecuted := false
 
-	mockEnv.hook.AfterRead(func(env *env, auth *dao.Auth, accessToken string) *HookError {
+	mockEnv.hook.AfterLogin(func(env *env, auth *dao.Auth, accessToken string) *HookError {
 		isHookExecuted = true
 		return nil
 	})
@@ -492,11 +492,11 @@ func TestReadAuthHandlerAfterHookSucceeds(t *testing.T) {
 	}
 }
 
-// Test that an after read hook is successfully invoked and request aborted
+// Test that an after login hook is successfully invoked and request aborted
 func TestReadAuthHandlerAfterHookAbortsRequest(t *testing.T) {
 	mockEnv := makeMockEnv()
 
-	mockEnv.hook.AfterRead(func(env *env, auth *dao.Auth, accessToken string) *HookError {
+	mockEnv.hook.AfterLogin(func(env *env, auth *dao.Auth, accessToken string) *HookError {
 		return &HookError{http.StatusTeapot, errors.New("Example")}
 	})
 

--- a/auth/hook.go
+++ b/auth/hook.go
@@ -5,11 +5,11 @@ import "github.com/TempleEight/spec-golang/auth/dao"
 // Hook allows additional code to be executed before and after every datastore interaction
 // Hooks are executed in the order they are defined, such that if any hook errors, future hooks are not executed and the request is terminated
 type Hook struct {
-	beforeCreateHooks []*func(env *env, req registerAuthRequest, input *dao.CreateAuthInput) *HookError
-	beforeReadHooks   []*func(env *env, req loginAuthRequest, input *dao.ReadAuthInput) *HookError
+	beforeRegisterHooks []*func(env *env, req registerAuthRequest, input *dao.CreateAuthInput) *HookError
+	beforeLoginHooks    []*func(env *env, req loginAuthRequest, input *dao.ReadAuthInput) *HookError
 
-	afterCreateHooks []*func(env *env, auth *dao.Auth, accessToken string) *HookError
-	afterReadHooks   []*func(env *env, auth *dao.Auth, accessToken string) *HookError
+	afterRegisterHooks []*func(env *env, auth *dao.Auth, accessToken string) *HookError
+	afterLoginHooks    []*func(env *env, auth *dao.Auth, accessToken string) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -22,22 +22,22 @@ func (e *HookError) Error() string {
 	return e.error.Error()
 }
 
-// BeforeCreate adds a new hook to be executed before creating an object in the data store
-func (h *Hook) BeforeCreate(hook func(env *env, req registerAuthRequest, input *dao.CreateAuthInput) *HookError) {
-	h.beforeCreateHooks = append(h.beforeCreateHooks, &hook)
+// BeforeRegister adds a new hook to be executed before creating an object in the data store
+func (h *Hook) BeforeRegister(hook func(env *env, req registerAuthRequest, input *dao.CreateAuthInput) *HookError) {
+	h.beforeRegisterHooks = append(h.beforeRegisterHooks, &hook)
 }
 
-// BeforeRead adds a new hook to be executed before reading an object in the datastore
-func (h *Hook) BeforeRead(hook func(env *env, req loginAuthRequest, input *dao.ReadAuthInput) *HookError) {
-	h.beforeReadHooks = append(h.beforeReadHooks, &hook)
+// BeforeLogin adds a new hook to be executed before reading an object in the datastore
+func (h *Hook) BeforeLogin(hook func(env *env, req loginAuthRequest, input *dao.ReadAuthInput) *HookError) {
+	h.beforeLoginHooks = append(h.beforeLoginHooks, &hook)
 }
 
-// AfterCreate adds a new hook to be executed after creating an object in the datastore
-func (h *Hook) AfterCreate(hook func(env *env, auth *dao.Auth, accessToken string) *HookError) {
-	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
+// AfterRegister adds a new hook to be executed after creating an object in the datastore
+func (h *Hook) AfterRegister(hook func(env *env, auth *dao.Auth, accessToken string) *HookError) {
+	h.afterRegisterHooks = append(h.afterRegisterHooks, &hook)
 }
 
-// AfterRead adds a new hook to be executed after reading an object in the datastore
-func (h *Hook) AfterRead(hook func(env *env, auth *dao.Auth, accessToken string) *HookError) {
-	h.afterReadHooks = append(h.afterReadHooks, &hook)
+// AfterLogin adds a new hook to be executed after reading an object in the datastore
+func (h *Hook) AfterLogin(hook func(env *env, auth *dao.Auth, accessToken string) *HookError) {
+	h.afterLoginHooks = append(h.afterLoginHooks, &hook)
 }


### PR DESCRIPTION
To be in keeping with the endpoint names in the auth service, rename the hooks to `register` and `login` rather than `create` and `read`