### PR TITLE
[user] Add delete picture endpoint

### DIFF
--- a/user/dao/dao.go
+++ b/user/dao/dao.go
@@ -24,6 +24,7 @@ type BaseDatastore interface {
 	CreatePicture(input CreatePictureInput) (*Picture, error)
 	ReadPicture(input ReadPictureInput) (*Picture, error)
 	UpdatePicture(input UpdatePictureInput) (*Picture, error)
+	DeletePicture(input DeletePictureInput) error
 }
 
 // DAO encapsulates access to the datastore
@@ -84,6 +85,12 @@ type UpdatePictureInput struct {
 	ID     uuid.UUID
 	UserID uuid.UUID
 	Img    []byte
+}
+
+// DeletePictureInput encapsulates the information required to delete a single picture in the datastore
+type DeletePictureInput struct {
+	ID     uuid.UUID
+	UserID uuid.UUID
 }
 
 // Init opens the datastore connection, returning a DAO
@@ -225,4 +232,16 @@ func (dao *DAO) UpdatePicture(input UpdatePictureInput) (*Picture, error) {
 	}
 
 	return &picture, nil
+}
+
+// DeletePicture deletes a single picture from the datastore
+func (dao *DAO) DeletePicture(input DeletePictureInput) error {
+	rowsAffected, err := executeQuery(dao.DB, "DELETE FROM picture WHERE id = $1 AND user_id = $2", input.ID, input.UserID)
+	if err != nil {
+		return err
+	} else if rowsAffected == 0 {
+		return ErrPictureNotFound(input.ID.String())
+	}
+
+	return nil
 }

--- a/user/hook.go
+++ b/user/hook.go
@@ -12,6 +12,7 @@ type Hook struct {
 	beforeCreatePictureHooks []*func(env *env, req createPictureRequest, input *dao.CreatePictureInput) *HookError
 	beforeReadPictureHooks   []*func(env *env, input *dao.ReadPictureInput) *HookError
 	beforeUpdatePictureHooks []*func(env *env, req updatePictureRequest, input *dao.UpdatePictureInput) *HookError
+	beforeDeletePictureHooks []*func(env *env, input *dao.DeletePictureInput) *HookError
 
 	afterCreateHooks        []*func(env *env, user *dao.User) *HookError
 	afterReadHooks          []*func(env *env, user *dao.User) *HookError
@@ -20,6 +21,7 @@ type Hook struct {
 	afterCreatePictureHooks []*func(env *env, picture *dao.Picture) *HookError
 	afterReadPictureHooks   []*func(env *env, picture *dao.Picture) *HookError
 	afterUpdatePictureHooks []*func(env *env, picture *dao.Picture) *HookError
+	afterDeletePictureHooks []*func(env *env) *HookError
 }
 
 // HookError wraps an existing error with HTTP status code
@@ -67,6 +69,11 @@ func (h *Hook) BeforeUpdatePicture(hook func(env *env, req updatePictureRequest,
 	h.beforeUpdatePictureHooks = append(h.beforeUpdatePictureHooks, &hook)
 }
 
+// BeforeDeletePicture adds a new hook to be executed before deletin an object in the datastore
+func (h *Hook) BeforeDeletePicture(hook func(env *env, input *dao.DeletePictureInput) *HookError) {
+	h.beforeDeletePictureHooks = append(h.beforeDeletePictureHooks, &hook)
+}
+
 // AfterCreate adds a new hook to be executed after creating an object in the datastore
 func (h *Hook) AfterCreate(hook func(env *env, user *dao.User) *HookError) {
 	h.afterCreateHooks = append(h.afterCreateHooks, &hook)
@@ -100,4 +107,9 @@ func (h *Hook) AfterReadPicture(hook func(env *env, user *dao.Picture) *HookErro
 // AfterUpdatePicture adds a new hook to be executed after reading an object in the datastore
 func (h *Hook) AfterUpdatePicture(hook func(env *env, user *dao.Picture) *HookError) {
 	h.afterUpdatePictureHooks = append(h.afterUpdatePictureHooks, &hook)
+}
+
+// AfterDeletePicture adds a new hook to be executed after deleting an object in the datastore
+func (h *Hook) AfterDeletePicture(hook func(env *env) *HookError) {
+	h.afterDeletePictureHooks = append(h.afterDeletePictureHooks, &hook)
 }

--- a/user/metric/metric.go
+++ b/user/metric/metric.go
@@ -13,6 +13,7 @@ var (
 	RequestCreatePicture = "create_picture"
 	RequestReadPicture   = "read_picture"
 	RequestUpdatePicture = "update_picture"
+	RequestDeletePicture = "delete_picture"
 
 	RequestSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "user_request_success_total",


### PR DESCRIPTION
The final one! We now have full CRUD operations on `structs`.

Manual testing:

```
BASE=${KONG_ENTRY:-"localhost:8000"}

ACCESS1=$(curl -s -X POST $BASE/api/auth/register -d "{\"email\":\"jay$RANDOM@test.com\", \"password\":\"abcdefgh\"}" | jq -r .AccessToken)

USER1=$(curl -s -X POST $BASE/api/user -d '{"name": "Jay"}' -H "Authorization: Bearer $ACCESS1" | jq -r .ID)

CAT=$(base64 ~/Downloads/cat.png)

PIC_ID=$(echo "{ \"img\": \"$CAT\" }" | curl -s -X POST $BASE/api/user/$USER1/picture -H "Authorization: Bearer $ACCESS1" -d @- | jq -r .ID)

curl -s -X GET $BASE/api/user/$USER1/picture/$PIC_ID -H "Authorization: Bearer $ACCESS1" | jq -r .Img | base64 -d > cat_reply.png

curl -s -X DELETE $BASE/api/user/$USER1/picture/$PIC_ID -H "Authorization: Bearer $ACCESS1" | jq -r .Img | base64 -d > dog_reply.png

curl -s -X GET $BASE/api/user/$USER1/picture/$PIC_ID -H "Authorization: Bearer $ACCESS1"
```