### PR TITLE
[match] Remove server set values from SQL query and use hooks instead

### DIFF
--- a/match/dao/dao.go
+++ b/match/dao/dao.go
@@ -42,10 +42,11 @@ type ListMatchInput struct {
 
 // CreateMatchInput encapsulates the information required to create a single match in the datastore
 type CreateMatchInput struct {
-	ID      uuid.UUID
-	AuthID  uuid.UUID
-	UserOne uuid.UUID
-	UserTwo uuid.UUID
+	ID        uuid.UUID
+	AuthID    uuid.UUID
+	UserOne   uuid.UUID
+	UserTwo   uuid.UUID
+	MatchedOn time.Time
 }
 
 // ReadMatchInput encapsulates the information required to read a single match in the datastore
@@ -55,9 +56,10 @@ type ReadMatchInput struct {
 
 // UpdateMatchInput encapsulates the information required to update a single match in the datastore
 type UpdateMatchInput struct {
-	ID      uuid.UUID
-	UserOne uuid.UUID
-	UserTwo uuid.UUID
+	ID        uuid.UUID
+	UserOne   uuid.UUID
+	UserTwo   uuid.UUID
+	MatchedOn time.Time
 }
 
 // DeleteMatchInput encapsulates the information required to delete a single match in the datastore
@@ -123,7 +125,7 @@ func (dao *DAO) ListMatch(input ListMatchInput) (*[]Match, error) {
 
 // CreateMatch creates a new match in the datastore, returning the newly created match
 func (dao *DAO) CreateMatch(input CreateMatchInput) (*Match, error) {
-	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO match (id, created_by, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, NOW()) RETURNING *", input.ID, input.AuthID, input.UserOne, input.UserTwo)
+	row := executeQueryWithRowResponse(dao.DB, "INSERT INTO match (id, created_by, userOne, userTwo, matchedOn) VALUES ($1, $2, $3, $4, $5) RETURNING *", input.ID, input.AuthID, input.UserOne, input.UserTwo, input.MatchedOn)
 
 	var match Match
 	err := row.Scan(&match.ID, &match.CreatedBy, &match.UserOne, &match.UserTwo, &match.MatchedOn)
@@ -154,7 +156,7 @@ func (dao *DAO) ReadMatch(input ReadMatchInput) (*Match, error) {
 
 // UpdateMatch updates a match in the datastore, returning the newly updated match
 func (dao *DAO) UpdateMatch(input UpdateMatchInput) (*Match, error) {
-	row := executeQueryWithRowResponse(dao.DB, "UPDATE match SET userOne = $1, userTwo = $2, matchedOn = NOW() WHERE id = $3 RETURNING *", input.UserOne, input.UserTwo, input.ID)
+	row := executeQueryWithRowResponse(dao.DB, "UPDATE match SET userOne = $1, userTwo = $2, matchedOn = $3 WHERE id = $4 RETURNING *", input.UserOne, input.UserTwo, input.MatchedOn, input.ID)
 
 	var match Match
 	err := row.Scan(&match.ID, &match.CreatedBy, &match.UserOne, &match.UserTwo, &match.MatchedOn)

--- a/match/dao/errors.go
+++ b/match/dao/errors.go
@@ -6,5 +6,5 @@ import "fmt"
 type ErrMatchNotFound string
 
 func (e ErrMatchNotFound) Error() string {
-	return fmt.Sprintf("match not found with ID %d", string(e))
+	return fmt.Sprintf("match not found with ID %s", string(e))
 }

--- a/match/setup.go
+++ b/match/setup.go
@@ -1,9 +1,18 @@
 package main
 
 import (
+	"time"
+
+	"github.com/TempleEight/spec-golang/match/dao"
 	"github.com/gorilla/mux"
 )
 
 func (e *env) setup(router *mux.Router) {
 	// Add user defined code here
+	e.hook.BeforeCreate(beforeCreateMatch)
+}
+
+func beforeCreateMatch(env *env, req createMatchRequest, input *dao.CreateMatchInput) *HookError {
+	input.MatchedOn = time.Now()
+	return nil
 }


### PR DESCRIPTION
Rather than using `NOW()` in Postgres, we've decided to pull all `@serverSet` values into the Hooks. This means that without providing a hook, the value stored will be the Go default.

These are usually pretty sensible (0, "", 0.0f etc.), with `time.Time` defaulting to *January 1st 0001 at 00:00.00*. I think this makes it clear to the end developer that they need to update this value somewhere, rather than us defaulting to `time.Now()`, even if that is probably the most common use case. 

This also gives a nice test of hooks, which from a bit of manual testing seem to work nicely:

```
BASE=${KONG_ENTRY:-"localhost:8000"}

ACCESS1=$(curl -s -X POST $BASE/api/auth/register -d "{\"email\":\"jay$RANDOM@test.com\", \"password\":\"abcdefgh\"}" | jq -r .AccessToken)
ACCESS2=$(curl -s -X POST $BASE/api/auth/register -d "{\"email\":\"jay$RANDOM@test.com\", \"password\":\"abcdefgh\"}" | jq -r .AccessToken)

USER1=$(curl -s -X POST $BASE/api/user -d '{"name": "Jay"}' -H "Authorization: Bearer $ACCESS1" | jq -r .ID)
USER2=$(curl -s -X POST $BASE/api/user -d '{"name": "Lewis"}' -H "Authorization: Bearer $ACCESS2" | jq -r .ID)

MATCH=$(curl -X POST $BASE/api/match -d "{\"UserOne\": \"$USER1\", \"UserTwo\": \"$USER2\"}" -H "Authorization: Bearer $ACCESS1" | jq -r .ID)
curl -s -X GET $BASE/api/match/$MATCH -H "Authorization: Bearer $ACCESS1" 
```
Without the hook produces:
```
{"ID":"...","UserOne":"...","UserTwo":"...","MatchedOn":"0001-01-01T00:00:00Z"}
```

With the hook produces (noting this time is in UTC):
```
{"ID":"...","UserOne":"...","UserTwo":"...","MatchedOn":"2020-04-05T11:50:35Z"}
```